### PR TITLE
feat: add options to helm scripts to generate annotations for referenced configmaps and secrets in deployment template 

### DIFF
--- a/scripts/helm/helmTemplate-svc-single.sh
+++ b/scripts/helm/helmTemplate-svc-single.sh
@@ -138,7 +138,7 @@ fi
 # Find image version and digest
 . "$SCRIPTS_FOLDER"/image-version-reader-v2.sh -e $environment -m $microservice $IMAGE_VERSION_READER_OPTIONS
 
-TEMPLATE_CMD="helm template "
+TEMPLATE_CMD="helm template --dry-run=server "
 if [[ $enable_debug == true ]]; then
     TEMPLATE_CMD=$TEMPLATE_CMD"--debug "
 fi

--- a/scripts/helm/helmTemplate-svc-single.sh
+++ b/scripts/helm/helmTemplate-svc-single.sh
@@ -16,7 +16,6 @@ help()
         [ -v | --verbose ] Show debug messages
         [ -sd | --skip-dep ] Skip Helm dependencies setup
         [ -dr | --dry-run ] Use Helm --dry-run=server option
-        [ -ch | --configmap-hash ] Create configmapHash key into deployment template 
         [ -h | --help ] This help"
     exit 2
 }
@@ -31,7 +30,6 @@ skip_dep=false
 dry_run=false
 verbose=false
 images_file=""
-configmap_hash=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -93,13 +91,6 @@ do
           dry_run=true
           step=1
           shift 1
-          ;;
-        -ch| --configmap-hash) 
-          [[ "${2:-}" ]] || "When specified, configmap hash cannot be null" || help
-
-          configmap_hash=$2
-          step=2
-          shift 2
           ;;
         -v| --verbose )
           verbose=true
@@ -168,17 +159,8 @@ if [[ $output_redirect == "console" ]]; then
   OUTPUT_TO=""
 fi
 
-if [[ $configmap_hash != "" ]]; then
-  values_file_path="$ROOT_DIR/microservices/$microservice/$ENV/values.yaml"
-  
-  yq eval ".deployment.configmapHash = \"$configmap_hash\"" "$values_file_path" > "$ROOT_DIR/microservices/$microservice/$ENV/values-with-configmap-hash.yaml"
-
-  #TEMPLATE_CMD=$TEMPLATE_CMD" $microservice interop-eks-microservice-chart/interop-eks-microservice-chart -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values-with-configmap-hash.yaml\" $OUTPUT_TO"
-  TEMPLATE_CMD=$TEMPLATE_CMD" $microservice "$ROOT_DIR/charts/interop-eks-microservice-chart" -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values-with-configmap-hash.yaml\" $OUTPUT_TO"
-else
-  #TEMPLATE_CMD=$TEMPLATE_CMD" $microservice interop-eks-microservice-chart/interop-eks-microservice-chart -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\" $OUTPUT_TO"
-  TEMPLATE_CMD=$TEMPLATE_CMD" $microservice "$ROOT_DIR/charts/interop-eks-microservice-chart" -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\" $OUTPUT_TO"
-fi
+#TEMPLATE_CMD=$TEMPLATE_CMD" $microservice interop-eks-microservice-chart/interop-eks-microservice-chart -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\" $OUTPUT_TO"
+TEMPLATE_CMD=$TEMPLATE_CMD" $microservice "$ROOT_DIR/charts/interop-eks-microservice-chart" -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\" $OUTPUT_TO"
 
 eval $TEMPLATE_CMD
 if [[ $verbose == true ]]; then

--- a/scripts/helm/helmTemplate-svc-single.sh
+++ b/scripts/helm/helmTemplate-svc-single.sh
@@ -16,6 +16,7 @@ help()
         [ -v | --verbose ] Show debug messages
         [ -sd | --skip-dep ] Skip Helm dependencies setup
         [ -dr | --dry-run ] Use Helm --dry-run=server option
+        [ -ch | --configmap-hash ] Create configmapHash key into deployment template 
         [ -h | --help ] This help"
     exit 2
 }
@@ -30,6 +31,7 @@ skip_dep=false
 dry_run=false
 verbose=false
 images_file=""
+configmap_hash=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -91,6 +93,13 @@ do
           dry_run=true
           step=1
           shift 1
+          ;;
+        -ch| --configmap-hash) 
+          [[ "${2:-}" ]] || "When specified, configmap hash cannot be null" || help
+
+          configmap_hash=$2
+          step=2
+          shift 2
           ;;
         -v| --verbose )
           verbose=true
@@ -159,8 +168,17 @@ if [[ $output_redirect == "console" ]]; then
   OUTPUT_TO=""
 fi
 
-#TEMPLATE_CMD=$TEMPLATE_CMD" $microservice interop-eks-microservice-chart/interop-eks-microservice-chart -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\" $OUTPUT_TO"
-TEMPLATE_CMD=$TEMPLATE_CMD" $microservice "$ROOT_DIR/charts/interop-eks-microservice-chart" -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\" $OUTPUT_TO"
+if [[ $configmap_hash != "" ]]; then
+  values_file_path="$ROOT_DIR/microservices/$microservice/$ENV/values.yaml"
+  
+  yq eval ".deployment.configmapHash = \"$configmap_hash\"" "$values_file_path" > "$ROOT_DIR/microservices/$microservice/$ENV/values-with-configmap-hash.yaml"
+
+  #TEMPLATE_CMD=$TEMPLATE_CMD" $microservice interop-eks-microservice-chart/interop-eks-microservice-chart -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values-with-configmap-hash.yaml\" $OUTPUT_TO"
+  TEMPLATE_CMD=$TEMPLATE_CMD" $microservice "$ROOT_DIR/charts/interop-eks-microservice-chart" -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values-with-configmap-hash.yaml\" $OUTPUT_TO"
+else
+  #TEMPLATE_CMD=$TEMPLATE_CMD" $microservice interop-eks-microservice-chart/interop-eks-microservice-chart -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\" $OUTPUT_TO"
+  TEMPLATE_CMD=$TEMPLATE_CMD" $microservice "$ROOT_DIR/charts/interop-eks-microservice-chart" -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\" $OUTPUT_TO"
+fi
 
 eval $TEMPLATE_CMD
 if [[ $verbose == true ]]; then

--- a/scripts/helm/helmTemplate-svc-single.sh
+++ b/scripts/helm/helmTemplate-svc-single.sh
@@ -15,6 +15,7 @@ help()
         [ -c | --clean ] Clean files and directories after script successfull execution
         [ -v | --verbose ] Show debug messages
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -dr | --dry-run ] Use Helm --dry-run=server option
         [ -h | --help ] This help"
     exit 2
 }
@@ -26,6 +27,7 @@ enable_debug=false
 post_clean=false
 output_redirect=""
 skip_dep=false
+dry_run=false
 verbose=false
 images_file=""
 
@@ -85,6 +87,11 @@ do
           step=1
           shift 1
           ;;
+        -dr | --dry-run)
+          dry_run=true
+          step=1
+          shift 1
+          ;;
         -v| --verbose )
           verbose=true
           step=1
@@ -138,9 +145,12 @@ fi
 # Find image version and digest
 . "$SCRIPTS_FOLDER"/image-version-reader-v2.sh -e $environment -m $microservice $IMAGE_VERSION_READER_OPTIONS
 
-TEMPLATE_CMD="helm template --dry-run=server "
+TEMPLATE_CMD="helm template "
 if [[ $enable_debug == true ]]; then
     TEMPLATE_CMD=$TEMPLATE_CMD"--debug "
+fi
+if [[ $dry_run == true ]]; then
+    TEMPLATE_CMD=$TEMPLATE_CMD"--dry-run=server "
 fi
 
 OUTPUT_FILE="\"$OUT_DIR/$microservice.out.yaml\""

--- a/scripts/helm/kubectlApply-svc-single-standalone.sh
+++ b/scripts/helm/kubectlApply-svc-single-standalone.sh
@@ -12,6 +12,7 @@ help()
         [ -i | --image ] File with microservice image tag and digest
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print template output on terminal
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -ftcf | --force-template-configmap-first ] Force a first helm template to get the configmap hash before performing a second helm template followed by kubectl apply
         [ -h | --help ] This help"
     exit 2
 }
@@ -24,6 +25,7 @@ post_clean=false
 output_redirect=""
 skip_dep=false
 images_file=""
+force_template_configmap_first=false
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -73,6 +75,11 @@ do
           ;;
         -sd | --skip-dep)
           skip_dep=true
+          step=1
+          shift 1
+          ;;
+        -ftcf | --force-template-configmap-first) 
+          force_template_configmap_first=true
           step=1
           shift 1
           ;;
@@ -130,4 +137,12 @@ fi
 HELM_TEMPLATE_SCRIPT="$SCRIPTS_FOLDER/helmTemplate-svc-single.sh"
 APPLY_CMD="kubectl apply --show-managed-fields=false -f -"
 
-"$HELM_TEMPLATE_SCRIPT" -e "$ENV" -m "$microservice" $OPTIONS | $APPLY_CMD
+if [[ $force_template_configmap_first == true ]]; then
+  CONFIGMAP_YAML=$("$HELM_TEMPLATE_SCRIPT" -e "$ENV" -m "$microservice" $OPTIONS | yq eval 'select(.kind == "ConfigMap")' -)
+  if [[ -n "$CONFIGMAP_YAML" ]]; then
+    CONFIGMAP_HASH=$(echo "$CONFIGMAP_YAML" | sha256sum | awk '{print $1}')
+    "$HELM_TEMPLATE_SCRIPT" -e "$ENV" -m "$microservice" --configmap-hash "$CONFIGMAP_HASH" --dry-run $OPTIONS | $APPLY_CMD
+  fi
+else
+  "$HELM_TEMPLATE_SCRIPT" -e "$ENV" -m "$microservice" $OPTIONS | $APPLY_CMD
+fi


### PR DESCRIPTION
This PR adds the `--dry-run=server` option to the `helm template` command in the `helmTemplate-svc-single.sh` script.
This option is necessary otherwise helm can't contact the Kubernetes API Server to get the configmaps and secrets referenced by a deployment. 
Source: https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function


Related PRs:
- [#43](https://github.com/pagopa/interop-analytics-deployment/pull/43) on interop-analytics-deployment
- [#34](https://github.com/pagopa/interop-eks-microservice-chart/pull/34) on interop-eks-microservice-chart