### PR TITLE
fix: helm dep command failure

### DIFF
--- a/scripts/helm/helmDep.sh
+++ b/scripts/helm/helmDep.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-help()
-{
+help() {
     echo "Usage: 
         [ -u | --untar ] Untar downloaded charts
         [ -v | --verbose ] Show debug messages
@@ -10,9 +9,12 @@ help()
     exit 2
 }
 
-PROJECT_DIR=${PROJECT_DIR:-$(pwd)}
-ROOT_DIR=$PROJECT_DIR
+PROJECT_DIR="${PROJECT_DIR:-$(pwd)}"
+ROOT_DIR="$PROJECT_DIR"
+
 SCRIPTS_FOLDER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+
 
 args=$#
 untar=false
@@ -23,33 +25,42 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -u| --untar )
-          untar=true
+            untar=true
           step=1
           shift 1
-          ;;
+            ;;
         -v| --verbose )
-          verbose=true
+            verbose=true
           step=1
           shift 1
-          ;;
+            ;;
         -h | --help )
-          help
-          ;;
+            help
+            ;;
         *)
-          echo "Unexpected option: $1"
-          help
+            echo "Unexpected option: $1"
+            help
 
-          ;;
+            ;;
     esac
 done
 
 function setupHelmDeps() 
 {
     untar=$1
+
+    cd "$ROOT_DIR"
+
+    if [[ $verbose == true ]]; then
+        echo "Creating directory charts"
+    fi
+    mkdir -p charts
+
+    if [[ $verbose == true ]]; then
+        echo "Copying Chart.yaml to charts"
+    fi
+    cp Chart.yaml charts/
     
-    cd $ROOT_DIR
-    
-    rm -rf charts
     echo "# Helm dependencies setup #"
     echo "-- Add PagoPA eks repos --"
     helm repo add interop-eks-microservice-chart https://pagopa.github.io/interop-eks-microservice-chart > /dev/null
@@ -62,31 +73,42 @@ function setupHelmDeps()
     if [[ $verbose == true ]]; then
         echo "-- Search PagoPA charts in repo --"
     fi
-    helm search repo interop-eks-microservice-chart > /dev/null
-    helm search repo interop-eks-cronjob-chart > /dev/null
+        helm search repo interop-eks-microservice-chart > /dev/null
+        helm search repo interop-eks-cronjob-chart > /dev/null
 
     if [[ $verbose == true ]]; then
         echo "-- List chart dependencies --"
     fi
-    helm dep list | awk '{printf "%-35s %-15s %-20s\n", $1, $2, $3}'
-    
+    helm dep list charts | awk '{printf "%-35s %-15s %-20s\n", $1, $2, $3}'
+
+    cd charts
+
     if [[ $verbose == true ]]; then
         echo "-- Build chart dependencies --"
     fi
     # only first time
-    #helm dep build 
+    #helm dep build
     dep_up_result=$(helm dep up)
     if [[ $verbose == true ]]; then
         echo $dep_up_result
     fi
 
-    if [[ $untar == true ]]; then
-        cd charts
-        for filename in *.tgz; do 
-            tar -xf "$filename" && rm -f "$filename";
-        done;
+    cd "$ROOT_DIR"
+    mkdir -p charts
+    
+    if [[ $untar == true ]]; then   
+        for filename in charts/charts/*.tgz; do 
+            [ -e "$filename" ] || continue
+            echo "Processing $filename"
+            basename_file=$(basename "$filename" .tgz)
+            chart_name="${basename_file%-*}"
+            target_dir="charts/$chart_name"
 
-        cd ..
+            echo "→ Extracting to $target_dir"
+            mkdir -p "$target_dir"
+            tar -xzf "$filename" -C "$target_dir" --strip-components=1
+            rm -f "$filename"
+        done    
     fi
 
     set +e
@@ -98,7 +120,7 @@ function setupHelmDeps()
     fi
     set -e
 
-    cd -
+    cd "$ROOT_DIR/charts"
     echo "-- Helm dependencies setup ended --"
     exit 0
 }

--- a/scripts/helm/helmDep.sh
+++ b/scripts/helm/helmDep.sh
@@ -25,23 +25,23 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -u| --untar )
-            untar=true
+          untar=true
           step=1
           shift 1
-            ;;
+          ;;
         -v| --verbose )
-            verbose=true
+          verbose=true
           step=1
           shift 1
-            ;;
+          ;;
         -h | --help )
-            help
-            ;;
+          help
+          ;;
         *)
-            echo "Unexpected option: $1"
-            help
+          echo "Unexpected option: $1"
+          help
 
-            ;;
+          ;;
     esac
 done
 
@@ -73,8 +73,8 @@ function setupHelmDeps()
     if [[ $verbose == true ]]; then
         echo "-- Search PagoPA charts in repo --"
     fi
-        helm search repo interop-eks-microservice-chart > /dev/null
-        helm search repo interop-eks-cronjob-chart > /dev/null
+    helm search repo interop-eks-microservice-chart > /dev/null
+    helm search repo interop-eks-cronjob-chart > /dev/null
 
     if [[ $verbose == true ]]; then
         echo "-- List chart dependencies --"

--- a/scripts/helm/helmDep.sh
+++ b/scripts/helm/helmDep.sh
@@ -117,17 +117,11 @@ function setupHelmDeps()
             mv charts/charts/*.tgz charts/
         fi
     fi
-    # Remove empty temp charts directory if it exists and if it is empty
-    if [[ -d charts/charts && -z "$(ls -A charts/charts)" ]]; then
-        if [[ $verbose == true ]]; then
-            echo "Removing empty temp charts directory"
-        fi
-        rmdir charts/charts
-    else
-        if [[ $verbose == true ]]; then
-            echo "charts temp directory is not empty, not removing it"
-        fi
+    # Remove temp charts directory
+    if [[ $verbose == true ]]; then
+        echo "Removing charts/charts directory"
     fi
+    rm -rf charts/charts
 
     set +e
     # Install helm diff plugin, first check if it is already installed

--- a/scripts/helm/helmDep.sh
+++ b/scripts/helm/helmDep.sh
@@ -108,16 +108,6 @@ function setupHelmDeps()
             tar -xzf "$filename" -C "$target_dir" --strip-components=1
             rm -f "$filename"
         done
-    else
-    #  Move downloaded charts not extracted to the root charts directory
-        if find charts/charts -maxdepth 1 -name '*.tgz' | grep -q .; then
-            if [[ $verbose == true ]]; then
-                echo "Moving charts to root charts directory"
-            fi
-            mv charts/charts/*.tgz charts/
-        fi
-    fi
-    # Remove temp charts directory
     if [[ $verbose == true ]]; then
         echo "Removing charts/charts directory"
     fi


### PR DESCRIPTION
### Summary

This PR updates the `helmDep.sh` script to ensure compatibility with Helm >= 3.17.3, which introduces  limits as part of the fix for [CVE-2025-32386](https://www.wiz.io/vulnerability-database/cve/cve-2025-32386).

Starting from this version, Helm enforces the following limits when processing chart archives:

- The **total decompressed size** of all files in a chart must not exceed **100 MiB**
- The **decompressed size of any single file** must not exceed **5 MiB**

If these thresholds are exceeded — even by unrelated files in the working directory — commands like `helm dep update` may fail with errors such as:

**Error: decompressed chart file "XYZ" is larger than the maximum file size 5242880**

### Changes

- The script now copies `Chart.yaml` into a dedicated `charts/` subdirectory before executing Helm dependency commands, to avoid conflicts with large files in the root folder. (such as kube-linter archive or terraform providers files)
- During the untar phase, `.tgz` chart packages are extracted into `charts/<chart_name>/` using `--strip-components=1`, maintaining compatibility with the expected folder structure in the repository.

