### PR TITLE
feat: add OpenAPI uploading to S3, OpenAPI templating to rest-apigw-openapi TF module

### DIFF
--- a/terraform/modules/rest-apigw-openapi/00-main.tf
+++ b/terraform/modules/rest-apigw-openapi/00-main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.46.0"
+      version = "~> 5.100.0"
     }
   }
 }

--- a/terraform/modules/rest-apigw-openapi/31-monitoring.tf
+++ b/terraform/modules/rest-apigw-openapi/31-monitoring.tf
@@ -22,6 +22,63 @@ resource "aws_cloudwatch_metric_alarm" "apigw_5xx" {
   datapoints_to_alarm = var.alarm_5xx_datapoints
 }
 
+resource "aws_cloudwatch_metric_alarm" "apigw_4xx" {
+  count = var.create_cloudwatch_alarm_4xx ? 1 : 0
+
+  alarm_name        = format("%s-apigw-4xx", local.rest_apigw_name)
+  alarm_description = format("%s 4xx errors", local.rest_apigw_name)
+
+  alarm_actions = var.maintenance_mode ? [] : [var.sns_topic_arn]
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+
+  threshold           = var.alarm_4xx_threshold_percentage
+  evaluation_periods  = var.alarm_4xx_eval_periods
+  datapoints_to_alarm = var.alarm_4xx_datapoints
+
+  metric_query {
+    id          = "e1"
+    label       = "4xxPercentage"
+    expression  = "(m1/m2)*100"
+    return_data = true
+  }
+
+  metric_query {
+    id          = "m1"
+    label       = "Count4xx"
+    return_data = false
+
+    metric {
+      stat        = "Sum"
+      period      = var.alarm_4xx_period
+      metric_name = "4XXError"
+      namespace   = "AWS/ApiGateway"
+
+      dimensions = {
+        ApiName = local.rest_apigw_name
+      }
+    }
+  }
+
+  metric_query {
+    id          = "m2"
+    label       = "PostTokenCount"
+    return_data = false
+
+    metric {
+      stat        = "Sum"
+      period      = var.alarm_4xx_period
+      metric_name = "Count"
+      namespace   = "AWS/ApiGateway"
+
+      dimensions = {
+        ApiName = local.rest_apigw_name
+      }
+    }
+  }
+}
+
 resource "aws_cloudwatch_dashboard" "this" {
   count = var.create_cloudwatch_dashboard ? 1 : 0
 

--- a/terraform/modules/rest-apigw-openapi/41-s3.tf
+++ b/terraform/modules/rest-apigw-openapi/41-s3.tf
@@ -1,0 +1,12 @@
+resource "aws_s3_object" "openapi" {
+  depends_on = [data.external.openapi_integration]
+
+  count = var.openapi_s3_bucket_name != null && var.openapi_s3_object_key != null ? 1 : 0
+
+  bucket = var.openapi_s3_bucket_name
+  key    = var.openapi_s3_object_key
+
+  content = data.external.openapi_integration.result.integrated_openapi_yaml
+
+  source_hash = md5(data.external.openapi_integration.result.integrated_openapi_yaml)
+}

--- a/terraform/modules/rest-apigw-openapi/98-variables.tf
+++ b/terraform/modules/rest-apigw-openapi/98-variables.tf
@@ -73,6 +73,12 @@ variable "create_cloudwatch_alarm" {
   type        = bool
 }
 
+variable "create_cloudwatch_alarm_4xx" {
+  description = "If true, a CloudWatch alarm for the 4XXError metric is created for the current API Gateway"
+  type        = bool
+  default     = false
+}
+
 variable "create_cloudwatch_dashboard" {
   description = "If true, a CloudWatch dashboard is created for the current API Gateway"
   type        = bool
@@ -106,4 +112,46 @@ variable "alarm_5xx_datapoints" {
   description = "Number of breaching datapoints in the evaluation period to trigger the 5xx APIGW alarm"
   type        = number
   default     = 0
+}
+
+variable "alarm_4xx_threshold_percentage" {
+  description = "Threshold to trigger 4xx APIGW alarm"
+  type        = number
+  default     = 0
+}
+
+variable "alarm_4xx_period" {
+  description = "Period (in seconds) over which the 4xx APIGW alarm statistic is applied"
+  type        = number
+  default     = 0
+}
+
+variable "alarm_4xx_eval_periods" {
+  description = "Number of periods to evaluate for the 4xx APIGW alarm"
+  type        = number
+  default     = 0
+}
+
+variable "alarm_4xx_datapoints" {
+  description = "Number of breaching datapoints in the evaluation period to trigger the 4xx APIGW alarm"
+  type        = number
+  default     = 0
+}
+
+variable "openapi_s3_bucket_name" {
+  description = "Name of the S3 bucket to store the OpenAPI definition"
+  type        = string
+  default     = null
+}
+
+variable "openapi_s3_object_key" {
+  description = "Key of the S3 object used to store the OpenAPI definition"
+  type        = string
+  default     = null
+}
+
+variable "templating_map" {
+  description = "Map of strings for OpenAPI templating"
+  type        = map(string)
+  default     = {}
 }

--- a/terraform/modules/rest-apigw-openapi/99-outputs.tf
+++ b/terraform/modules/rest-apigw-openapi/99-outputs.tf
@@ -7,3 +7,8 @@ output "apigw_id" {
   description = "ID of the APIGW managed by this module"
   value       = aws_api_gateway_rest_api.this.id
 }
+
+output "apigw_stage_name" {
+  description = "Name of the stage of the APIGW managed by this module"
+  value       = aws_api_gateway_stage.env.stage_name
+}


### PR DESCRIPTION
This PR on the `rest-apigw-openapi` TF module:

- upgrades the aws provider version to 5.100.0;
- adds the OpenAPI uploading to S3 feature;
- adds the OpenAPI templating feature;
- adds the `apigw_stage_name` output to the module.