### PR TITLE
feat:separated charts for each environment

### DIFF
--- a/.github/workflows/common-deployment-values-validation.yaml
+++ b/.github/workflows/common-deployment-values-validation.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           echo "Using infra_commons_tag: $INFRA_COMMONS_TAG"
           echo "Using strict_kube_linter_checks: ${{ inputs.strict_kube_linter_checks }}"
-          echo "Using environment: ${{ inputs.environment }}"
+          echo "Using environment: $ENVIRONMENT"
 
       - name: Checkout scripts repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
@@ -57,6 +57,7 @@ jobs:
         id: helm_lint
         env:
           CHART_TYPE: ${{ matrix.chartType }}
+          ENVIRONMENT: ${{ inputs.environment }}
         run: |
           set -euo pipefail
 
@@ -72,15 +73,15 @@ jobs:
           fi
 
           export PROJECT_DIR=$(pwd)
-          CHART_PATH="./commons/${{ inputs.environment }}/Chart.yaml"
+          CHART_PATH="./commons/$ENVIRONMENT/Chart.yaml"
 
           $SCRIPTS_FOLDER/helmLint-main.sh \
           --debug \
-          --environment ${{ inputs.environment }} \
+          --environment $ENVIRONMENT \
           --output console \
           $OPTIONS \
           --chart-path $CHART_PATH \
-          -i $PROJECT_DIR/commons/${{ inputs.environment }}/images.yaml
+          -i $PROJECT_DIR/commons/$ENVIRONMENT/images.yaml
 
   microservices_validation:
     name: Microservices - Template & Lint

--- a/.github/workflows/common-deployment-values-validation.yaml
+++ b/.github/workflows/common-deployment-values-validation.yaml
@@ -72,7 +72,7 @@ jobs:
           fi
 
           export PROJECT_DIR=$(pwd)
-          CHART_PATH="./commons/${{ inputs.environment }}"
+          CHART_PATH="./commons/${{ inputs.environment }}/Chart.yaml"
 
           $SCRIPTS_FOLDER/helmLint-main.sh \
           --debug \

--- a/.github/workflows/common-deployment-values-validation.yaml
+++ b/.github/workflows/common-deployment-values-validation.yaml
@@ -14,7 +14,7 @@ on:
         description: 'Enable strict kube-linter checks'
         required: false
         type: boolean
-        default: false
+
 
 defaults:
   run:
@@ -36,11 +36,13 @@ jobs:
         id: checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
 
-      - name: Print tag passed in
+      - name: Print inputs passed in
         env:
           INFRA_COMMONS_TAG: ${{ inputs.infra_commons_tag }}
         run: |
           echo "Using infra_commons_tag: $INFRA_COMMONS_TAG"
+          echo "Using strict_kube_linter_checks: ${{ inputs.strict_kube_linter_checks }}"
+          echo "Using environment: ${{ inputs.environment }}"
 
       - name: Checkout scripts repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
@@ -70,8 +72,15 @@ jobs:
           fi
 
           export PROJECT_DIR=$(pwd)
+          CHART_PATH="./commons/${{ inputs.environment }}"
 
-          $SCRIPTS_FOLDER/helmLint-main.sh --debug --environment ${{ inputs.environment }} --output console $OPTIONS -i $PROJECT_DIR/commons/$INFRA_COMMONS_TAG/images.yaml
+          $SCRIPTS_FOLDER/helmLint-main.sh \
+          --debug \
+          --environment ${{ inputs.environment }} \
+          --output console \
+          $OPTIONS \
+          --chart-path $CHART_PATH \
+          -i $PROJECT_DIR/commons/${{ inputs.environment }}/images.yaml
 
   microservices_validation:
     name: Microservices - Template & Lint

--- a/scripts/helm/helmDep.sh
+++ b/scripts/helm/helmDep.sh
@@ -49,6 +49,7 @@ do
           help
           ;;
         -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
           chart_path="$2"
           step=2
           shift 2

--- a/scripts/helm/helmDep.sh
+++ b/scripts/helm/helmDep.sh
@@ -61,7 +61,7 @@ do
     esac
 done
 
-
+# Validate path to Chart.yaml
 if [[ -n "$chart_path" ]]; then
     resolved_chart_path="$chart_path"
 else
@@ -172,4 +172,4 @@ function setupHelmDeps()
     exit 0
 }
 
-setupHelmDeps $untar "$verbose"
+setupHelmDeps $untar

--- a/scripts/helm/helmDep.sh
+++ b/scripts/helm/helmDep.sh
@@ -5,6 +5,7 @@ help() {
     echo "Usage:
         [ -u | --untar ] Untar downloaded charts
         [ -v | --verbose ] Show debug messages
+        [ -cp | --chart-path ] Path to Chart.yaml (default: ./Chart.yaml)
         [ -h | --help ] This help"
     exit 2
 }
@@ -13,13 +14,14 @@ PROJECT_DIR="${PROJECT_DIR:-$(pwd)}"
 ROOT_DIR="$PROJECT_DIR"
 
 SCRIPTS_FOLDER="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
+CHART_PATH="${CHART_PATH:-Chart.yaml}"
 
 
 args=$#
 untar=false
 step=1
 verbose=false
+
 # Check args
 for (( i=0; i<$args; i+=$step ))
 do
@@ -36,6 +38,11 @@ do
           ;;
         -h | --help )
           help
+          ;;
+        -cp | --chart-path )
+          CHART_PATH="$2"
+          step=2
+          shift 2
           ;;
         *)
           echo "Unexpected option: $1"
@@ -59,7 +66,7 @@ function setupHelmDeps()
     if [[ $verbose == true ]]; then
         echo "Copying Chart.yaml to charts"
     fi
-    cp Chart.yaml charts/
+    cp "$CHART_PATH" charts/Chart.yaml
     # Execute helm commands
     echo "# Helm dependencies setup #"
     echo "-- Add PagoPA eks repos --"

--- a/scripts/helm/helmDiff-cron-single-standalone.sh
+++ b/scripts/helm/helmDiff-cron-single-standalone.sh
@@ -89,8 +89,14 @@ if [[ -z $job || $job == "" ]]; then
   echo "Job cannot null"
   help
 fi
+
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/helmDiff-cron-single-standalone.sh
+++ b/scripts/helm/helmDiff-cron-single-standalone.sh
@@ -13,6 +13,7 @@ help()
         [ -j | --job ] Cronjob defined in jobs folder
         [ -i | --image ] File with cronjob image tag and digest
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -24,6 +25,7 @@ enable_debug=false
 post_clean=false
 skip_dep=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -43,7 +45,7 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-          
+
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -57,7 +59,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -65,6 +67,12 @@ do
           skip_dep=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -87,7 +95,7 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
 

--- a/scripts/helm/helmDiff-cron-single-standalone.sh
+++ b/scripts/helm/helmDiff-cron-single-standalone.sh
@@ -33,7 +33,6 @@ do
     case "$1" in
         -e| --environment )
             [[ "${2:-}" ]] || "Environment cannot be null" || help
-
           environment=$2
           step=2
           shift 2
@@ -45,7 +44,6 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -53,13 +51,11 @@ do
               echo "Allowed values: " $(getAllowedCronjobs)
               help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -80,7 +76,6 @@ do
         *)
           echo "Unexpected option: $1"
           help
-
           ;;
     esac
 done

--- a/scripts/helm/helmDiff-main.sh
+++ b/scripts/helm/helmDiff-main.sh
@@ -17,6 +17,7 @@ help()
         [ -i | --image ] File with microservices and cronjobs images tag and digest
         [ -dtl | --disable-templating-lookup ] Disable Helm --dry-run=server option in order to avoid lookup configmaps and secrets when templating
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -30,6 +31,7 @@ post_clean=false
 skip_dep=false
 images_file=""
 disable_templating_lookup=false
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -59,7 +61,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -72,6 +74,12 @@ do
           disable_templating_lookup=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -104,11 +112,15 @@ fi
 if [[ -n $images_file ]]; then
   OPTIONS=$OPTIONS" -i $images_file"
 fi
+if [[ -n $chart_path ]]; then
+  OPTIONS=$OPTIONS" -cp $chart_path"
+fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
-# Skip further execution of helm deps build and update since we have already done it in the previous line 
+
+# Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd"
 
 MICROSERVICE_OPTIONS=" "
@@ -123,7 +135,7 @@ if [[ $template_microservices == true ]]; then
   if [[ -z $ALLOWED_MICROSERVICES || $ALLOWED_MICROSERVICES == "" ]]; then
     echo "No microservices found for environment '$ENV'. Skipping microservices diff."
   fi
-  
+
   for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
   do
     echo "Diff $CURRENT_SVC"
@@ -134,11 +146,11 @@ fi
 if [[ $template_jobs == true ]]; then
   echo "Start cronjobs templates diff"
   ALLOWED_CRONJOBS=$(getAllowedCronjobsForEnvironment "$ENV")
-  
+
   if [[ -z $ALLOWED_CRONJOBS || $ALLOWED_CRONJOBS == "" ]]; then
     echo "No cronjobs found for environment '$ENV'. Skipping cronjobs diff."
   fi
-  
+
   for CURRENT_JOB in ${ALLOWED_CRONJOBS//;/ }
   do
     echo "Diff $CURRENT_JOB"

--- a/scripts/helm/helmDiff-main.sh
+++ b/scripts/helm/helmDiff-main.sh
@@ -39,7 +39,6 @@ do
     case "$1" in
         -e| --environment )
             [[ "${2:-}" ]] || "Environment cannot be null" || help
-
           environment=$2
           step=2
           shift 2
@@ -61,7 +60,6 @@ do
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;

--- a/scripts/helm/helmDiff-main.sh
+++ b/scripts/helm/helmDiff-main.sh
@@ -114,7 +114,12 @@ if [[ -n $chart_path ]]; then
   OPTIONS=$OPTIONS" -cp $chart_path"
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/helmDiff-svc-single-standalone.sh
+++ b/scripts/helm/helmDiff-svc-single-standalone.sh
@@ -14,6 +14,7 @@ help()
         [ -i | --image ] File with microservice image tag and digest
         [ -sd | --skip-dep ] Skip Helm dependencies setup
         [ -dtl | --disable-templating-lookup ] Disable Helm --dry-run=server option in order to avoid lookup configmaps and secrets when templating
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -26,6 +27,7 @@ post_clean=false
 skip_dep=false
 images_file=""
 disable_templating_lookup=false
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -59,7 +61,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -72,6 +74,12 @@ do
           disable_templating_lookup=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -93,7 +101,7 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
 

--- a/scripts/helm/helmDiff-svc-single-standalone.sh
+++ b/scripts/helm/helmDiff-svc-single-standalone.sh
@@ -35,7 +35,6 @@ do
     case "$1" in
         -e| --environment )
             [[ "${2:-}" ]] || "Environment cannot be null" || help
-
           environment=$2
           step=2
           shift 2
@@ -55,13 +54,11 @@ do
             echo "Allowed values: " $(getAllowedMicroservices)
             help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -87,7 +84,6 @@ do
         *)
           echo "Unexpected option: $1"
           help
-
           ;;
     esac
 done

--- a/scripts/helm/helmDiff-svc-single-standalone.sh
+++ b/scripts/helm/helmDiff-svc-single-standalone.sh
@@ -97,7 +97,12 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/helmLint-cron-single.sh
+++ b/scripts/helm/helmLint-cron-single.sh
@@ -15,7 +15,7 @@ help()
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print linting output on terminal
         [ -c | --clean ] Clean files and directories after script successfull execution
         [ -sd | --skip-dep ] Skip Helm dependencies setup
-        [ -cp | --chart-path ] Path to Chart.yaml (default: ./Chart.yaml)
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -57,7 +57,6 @@ do
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -72,7 +71,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -87,7 +85,7 @@ do
           shift 1
           ;;
         -cp | --chart-path )
-          [[ "${2:-}" ]] || "When specified, chart path cannot be null" || help
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
           chart_path=$2
           step=2
           shift 2
@@ -112,7 +110,7 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path"
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$resolved_chart_path" --environment "$environment"
 fi
 
 VALID_CONFIG=$(isCronjobEnvConfigValid $job $environment)

--- a/scripts/helm/helmLint-cron-single.sh
+++ b/scripts/helm/helmLint-cron-single.sh
@@ -110,7 +110,12 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$resolved_chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
 fi
 
 VALID_CONFIG=$(isCronjobEnvConfigValid $job $environment)

--- a/scripts/helm/helmLint-cron-single.sh
+++ b/scripts/helm/helmLint-cron-single.sh
@@ -15,6 +15,7 @@ help()
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print linting output on terminal
         [ -c | --clean ] Clean files and directories after script successfull execution
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml (default: ./Chart.yaml)
         [ -h | --help ] This help"
     exit 2
 }
@@ -27,6 +28,7 @@ post_clean=false
 output_redirect=""
 skip_dep=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -55,7 +57,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -84,6 +86,12 @@ do
           step=1
           shift 1
           ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || "When specified, chart path cannot be null" || help
+          chart_path=$2
+          step=2
+          shift 2
+          ;;
         -h | --help )
           help
           ;;
@@ -104,7 +112,7 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path"
 fi
 
 VALID_CONFIG=$(isCronjobEnvConfigValid $job $environment)
@@ -131,9 +139,9 @@ fi
 # Find image version and digest
 bash "$SCRIPTS_FOLDER"/image-version-reader-v2.sh -e $environment -j $job $IMAGE_VERSION_READER_OPTIONS
 
-LINT_CMD="helm lint "
+LINT_CMD="helm lint"
 if [[ $enable_debug == true ]]; then
-    LINT_CMD=$LINT_CMD"--debug "
+  LINT_CMD+=" --debug"
 fi
 
 OUTPUT_TO="> \"$OUT_DIR/$job.out.yaml\""
@@ -141,7 +149,11 @@ if [[ $output_redirect == "console" ]]; then
   OUTPUT_TO=""
 fi
 
-LINT_CMD=$LINT_CMD" \"$ROOT_DIR/charts/interop-eks-cronjob-chart\" -f \"$ROOT_DIR/charts/interop-eks-cronjob-chart/values.yaml\" -f \"$ROOT_DIR/commons/$ENV/values-cronjob.compiled.yaml\" -f \"$ROOT_DIR/jobs/$job/$ENV/values.yaml\" $OUTPUT_TO"
+LINT_CMD+=" \"$ROOT_DIR/charts/interop-eks-cronjob-chart\""
+LINT_CMD+=" -f \"$ROOT_DIR/commons/$ENV/values-cronjob.compiled.yaml\""
+LINT_CMD+=" -f \"$ROOT_DIR/jobs/$job/$ENV/values.yaml\""
+LINT_CMD+=" --set enableLookup=false"
+LINT_CMD+=" $OUTPUT_TO"
 
 eval $LINT_CMD
 

--- a/scripts/helm/helmLint-cron-single.sh
+++ b/scripts/helm/helmLint-cron-single.sh
@@ -146,11 +146,12 @@ OUTPUT_TO="> \"$OUT_DIR/$job.out.yaml\""
 if [[ $output_redirect == "console" ]]; then
   OUTPUT_TO=""
 fi
+#LINT_CMD=$LINT_CMD" \"$ROOT_DIR/charts/interop-eks-cronjob-chart\" -f \"$ROOT_DIR/charts/interop-eks-cronjob-chart/values.yaml\" -f \"$ROOT_DIR/commons/$ENV/values-cronjob.compiled.yaml\" -f \"$ROOT_DIR/jobs/$job/$ENV/values.yaml\" $OUTPUT_TO"
 
 LINT_CMD+=" \"$ROOT_DIR/charts/interop-eks-cronjob-chart\""
+LINT_CMD+=" -f \"$ROOT_DIR/charts/interop-eks-cronjob-chart/values.yaml\""
 LINT_CMD+=" -f \"$ROOT_DIR/commons/$ENV/values-cronjob.compiled.yaml\""
 LINT_CMD+=" -f \"$ROOT_DIR/jobs/$job/$ENV/values.yaml\""
-LINT_CMD+=" --set enableLookup=false"
 LINT_CMD+=" $OUTPUT_TO"
 
 eval $LINT_CMD

--- a/scripts/helm/helmLint-main.sh
+++ b/scripts/helm/helmLint-main.sh
@@ -138,16 +138,16 @@ if [[ $lint_microservices == true ]]; then
   echo "Start linting microservices"
   ALLOWED_MICROSERVICES=$(getAllowedMicroservicesForEnvironment "$ENV")
   if [[ -z $ALLOWED_MICROSERVICES || $ALLOWED_MICROSERVICES == "" ]]; then
-      echo "No microservices found for environment '$ENV'. Skipping microservices linting."
+    echo "No microservices found for environment '$ENV'. Skipping microservices linting."
   fi
   for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
   do
     echo "Linting $CURRENT_SVC"
     VALID_CONFIG=$(isMicroserviceEnvConfigValid $CURRENT_SVC $ENV)
     if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
-        echo "Environment configuration '$ENV' not found for microservice '$CURRENT_SVC'. Skip"
+      echo "Environment configuration '$ENV' not found for microservice '$CURRENT_SVC'. Skip"
     else
-        "$SCRIPTS_FOLDER"/helmLint-svc-single.sh -e $ENV -m $CURRENT_SVC $OPTIONS
+      "$SCRIPTS_FOLDER"/helmLint-svc-single.sh -e $ENV -m $CURRENT_SVC $OPTIONS
     fi
   done
 fi
@@ -165,11 +165,11 @@ if [[ $lint_jobs == true ]]; then
     if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
       echo "Environment configuration '$ENV' not found for cronjob '$CURRENT_JOB'"
     else
-    "$SCRIPTS_FOLDER"/helmLint-cron-single.sh -e $ENV -j $CURRENT_JOB $OPTIONS
+      "$SCRIPTS_FOLDER"/helmLint-cron-single.sh -e $ENV -j $CURRENT_JOB $OPTIONS
     fi
   done
 fi
 
 if [[ $post_clean == true ]]; then
-    rm -rf "$ROOT_DIR/out/lint"
+  rm -rf "$ROOT_DIR/out/lint"
 fi

--- a/scripts/helm/helmLint-main.sh
+++ b/scripts/helm/helmLint-main.sh
@@ -39,66 +39,63 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
-            environment=$2
-            step=2
-            shift 2
-            ;;
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
+          environment=$2
+          step=2
+          shift 2
+          ;;
         -m | --microservices )
-            lint_microservices=true
-            step=1
-            shift 1
-            ;;
+          lint_microservices=true
+          step=1
+          shift 1
+          ;;
         -j | --jobs )
-            lint_jobs=true
-            step=1
-            shift 1
-            ;;
+          lint_jobs=true
+          step=1
+          shift 1
+          ;;
         -i | --image )
-            images_file=$2
-
-            step=2
-            shift 2
-            ;;
+          images_file=$2
+          step=2
+          shift 2
+          ;;
         -d | --debug)
-            enable_debug=true
-            step=1
-            shift 1
-            ;;
+          enable_debug=true
+          step=1
+          shift 1
+          ;;
         -o | --output)
-            [[ "${2:-}" ]] || "When specified, output cannot be null" || help
-            output_redirect=$2
-            if [[ $output_redirect != "console" ]]; then
-                help
-            fi
-
-            step=2
-            shift 2
-            ;;
+          [[ "${2:-}" ]] || "When specified, output cannot be null" || help
+          output_redirect=$2
+          if [[ $output_redirect != "console" ]]; then
+             help
+          fi
+          step=2
+          shift 2
+          ;;
         -c | --clean)
-            post_clean=true
-            step=1
-            shift 1
-            ;;
+          post_clean=true
+          step=1
+          shift 1
+          ;;
         -sd | --skip-dep)
-            skip_dep=true
-            step=1
-            shift 1
-            ;;
+          skip_dep=true
+          step=1
+          shift 1
+          ;;
         -cp | --chart-path )
-            [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
-            chart_path=$2
-            step=2
-            shift 2
-            ;;
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
+          ;;
         -h | --help )
-            help
-            ;;
+          help
+          ;;
         *)
-            echo "Unexpected option: $1"
-            help
-            ;;
+          echo "Unexpected option: $1"
+          help
+          ;;
     esac
 done
 echo "Arguments: $@"

--- a/scripts/helm/helmLint-main.sh
+++ b/scripts/helm/helmLint-main.sh
@@ -142,13 +142,13 @@ if [[ $lint_microservices == true ]]; then
   fi
   for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
   do
-      echo "Linting $CURRENT_SVC"
-      VALID_CONFIG=$(isMicroserviceEnvConfigValid $CURRENT_SVC $ENV)
-      if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
-          echo "Environment configuration '$ENV' not found for microservice '$CURRENT_SVC'. Skip"
-      else
-          "$SCRIPTS_FOLDER"/helmLint-svc-single.sh -e $ENV -m $CURRENT_SVC $OPTIONS
-      fi
+    echo "Linting $CURRENT_SVC"
+    VALID_CONFIG=$(isMicroserviceEnvConfigValid $CURRENT_SVC $ENV)
+    if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
+        echo "Environment configuration '$ENV' not found for microservice '$CURRENT_SVC'. Skip"
+    else
+        "$SCRIPTS_FOLDER"/helmLint-svc-single.sh -e $ENV -m $CURRENT_SVC $OPTIONS
+    fi
   done
 fi
 
@@ -156,17 +156,17 @@ if [[ $lint_jobs == true ]]; then
   echo "Start linting cronjobs"
   ALLOWED_CRONJOBS=$(getAllowedCronjobsForEnvironment "$ENV")
   if [[ -z $ALLOWED_CRONJOBS || $ALLOWED_CRONJOBS == "" ]]; then
-      echo "No cronjobs found for environment '$ENV'. Skipping cronjobs linting."
+    echo "No cronjobs found for environment '$ENV'. Skipping cronjobs linting."
   fi
   for CURRENT_JOB in ${ALLOWED_CRONJOBS//;/ }
   do
-      echo "Linting $CURRENT_JOB"
-      VALID_CONFIG=$(isCronjobEnvConfigValid $CURRENT_JOB $ENV)
-      if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
-          echo "Environment configuration '$ENV' not found for cronjob '$CURRENT_JOB'"
-      else
+    echo "Linting $CURRENT_JOB"
+    VALID_CONFIG=$(isCronjobEnvConfigValid $CURRENT_JOB $ENV)
+    if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
+      echo "Environment configuration '$ENV' not found for cronjob '$CURRENT_JOB'"
+    else
     "$SCRIPTS_FOLDER"/helmLint-cron-single.sh -e $ENV -j $CURRENT_JOB $OPTIONS
-      fi
+    fi
   done
 fi
 

--- a/scripts/helm/helmLint-main.sh
+++ b/scripts/helm/helmLint-main.sh
@@ -18,6 +18,7 @@ help()
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print linting output on terminal
         [ -c | --clean ] Clean files and directories after scripts successfull execution
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml (default: ./Chart.yaml)
         [ -h | --help ] This help"
     exit 2
 }
@@ -31,6 +32,7 @@ post_clean=false
 output_redirect=""
 skip_dep=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -55,7 +57,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -84,6 +86,11 @@ do
           step=1
           shift 1
           ;;
+        -cp | --chart-path )
+          chart_path=$2
+          step=2
+          shift 2
+          ;;
         -h | --help )
           help
           ;;
@@ -93,7 +100,23 @@ do
           ;;
     esac
 done
+echo "Arguments: $@"
 
+# Uses default Chart.yaml path if not specified
+chart_path="${chart_path:-$PROJECT_DIR/Chart.yaml}"
+
+# If chart_path is a valid directory, try to use Chart.yaml inside it
+if [[ -d "$chart_path" ]]; then
+  if [[ -f "$chart_path/Chart.yaml" ]]; then
+    chart_path="$chart_path/Chart.yaml"
+  else
+    echo "Error: Chart.yaml not found in directory '$chart_path'"
+    exit 1
+  fi
+elif [[ ! -f "$chart_path" ]]; then
+  echo "Error: Specified chart_path '$chart_path' does not exist"
+  exit 1
+fi
 
 if [[ -z $environment || $environment == "" ]]; then
   echo "Environment cannot be null"
@@ -119,21 +142,26 @@ fi
 if [[ -n $images_file ]]; then
   OPTIONS=$OPTIONS" -i $images_file"
 fi
-if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
-fi
-# Skip further execution of helm deps build and update since we have already done it in the previous line 
-OPTIONS=$OPTIONS" -sd"
 
+if [[ $skip_dep == false ]]; then
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path"
+fi
+
+if [[ -n $chart_path ]]; then
+  OPTIONS=$OPTIONS" -cp $chart_path"
+fi
+
+# Skip further execution of helm deps build and update since we have already done it in the previous line
+OPTIONS=$OPTIONS" -sd"
 
 if [[ $lint_microservices == true ]]; then
   echo "Start linting microservices"
   ALLOWED_MICROSERVICES=$(getAllowedMicroservicesForEnvironment "$ENV")
-  
+
   if [[ -z $ALLOWED_MICROSERVICES || $ALLOWED_MICROSERVICES == "" ]]; then
     echo "No microservices found for environment '$ENV'. Skipping microservices linting."
   fi
-  
+
   for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
   do
     echo "Linting $CURRENT_SVC"
@@ -149,7 +177,7 @@ fi
 if [[ $lint_jobs == true ]]; then
   echo "Start linting cronjobs"
   ALLOWED_CRONJOBS=$(getAllowedCronjobsForEnvironment "$ENV")
-  
+
   if [[ -z $ALLOWED_CRONJOBS || $ALLOWED_CRONJOBS == "" ]]; then
     echo "No cronjobs found for environment '$ENV'. Skipping cronjobs linting."
   fi

--- a/scripts/helm/helmLint-main.sh
+++ b/scripts/helm/helmLint-main.sh
@@ -18,7 +18,7 @@ help()
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print linting output on terminal
         [ -c | --clean ] Clean files and directories after scripts successfull execution
         [ -sd | --skip-dep ] Skip Helm dependencies setup
-        [ -cp | --chart-path ] Path to Chart.yaml (default: ./Chart.yaml)
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -41,86 +41,71 @@ do
         -e| --environment )
             [[ "${2:-}" ]] || "Environment cannot be null" || help
 
-          environment=$2
-          step=2
-          shift 2
-          ;;
+            environment=$2
+            step=2
+            shift 2
+            ;;
         -m | --microservices )
-          lint_microservices=true
-          step=1
-          shift 1
-          ;;
+            lint_microservices=true
+            step=1
+            shift 1
+            ;;
         -j | --jobs )
-          lint_jobs=true
-          step=1
-          shift 1
-          ;;
+            lint_jobs=true
+            step=1
+            shift 1
+            ;;
         -i | --image )
-          images_file=$2
+            images_file=$2
 
-          step=2
-          shift 2
-          ;;
+            step=2
+            shift 2
+            ;;
         -d | --debug)
-          enable_debug=true
-          step=1
-          shift 1
-          ;;
+            enable_debug=true
+            step=1
+            shift 1
+            ;;
         -o | --output)
-          [[ "${2:-}" ]] || "When specified, output cannot be null" || help
-          output_redirect=$2
-          if [[ $output_redirect != "console" ]]; then
-            help
-          fi
+            [[ "${2:-}" ]] || "When specified, output cannot be null" || help
+            output_redirect=$2
+            if [[ $output_redirect != "console" ]]; then
+                help
+            fi
 
-          step=2
-          shift 2
-          ;;
+            step=2
+            shift 2
+            ;;
         -c | --clean)
-          post_clean=true
-          step=1
-          shift 1
-          ;;
+            post_clean=true
+            step=1
+            shift 1
+            ;;
         -sd | --skip-dep)
-          skip_dep=true
-          step=1
-          shift 1
-          ;;
+            skip_dep=true
+            step=1
+            shift 1
+            ;;
         -cp | --chart-path )
-          chart_path=$2
-          step=2
-          shift 2
-          ;;
+            [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+            chart_path=$2
+            step=2
+            shift 2
+            ;;
         -h | --help )
-          help
-          ;;
+            help
+            ;;
         *)
-          echo "Unexpected option: $1"
-          help
-          ;;
+            echo "Unexpected option: $1"
+            help
+            ;;
     esac
 done
 echo "Arguments: $@"
 
-# Uses default Chart.yaml path if not specified
-chart_path="${chart_path:-$PROJECT_DIR/Chart.yaml}"
-
-# If chart_path is a valid directory, try to use Chart.yaml inside it
-if [[ -d "$chart_path" ]]; then
-  if [[ -f "$chart_path/Chart.yaml" ]]; then
-    chart_path="$chart_path/Chart.yaml"
-  else
-    echo "Error: Chart.yaml not found in directory '$chart_path'"
-    exit 1
-  fi
-elif [[ ! -f "$chart_path" ]]; then
-  echo "Error: Specified chart_path '$chart_path' does not exist"
-  exit 1
-fi
-
 if [[ -z $environment || $environment == "" ]]; then
-  echo "Environment cannot be null"
-  help
+    echo "Environment cannot be null"
+    help
 fi
 echo "Environment: $environment"
 
@@ -143,57 +128,57 @@ if [[ -n $images_file ]]; then
   OPTIONS=$OPTIONS" -i $images_file"
 fi
 
-if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path"
-fi
-
 if [[ -n $chart_path ]]; then
-  OPTIONS=$OPTIONS" -cp $chart_path"
+    OPTIONS=$OPTIONS" -cp $chart_path"
+fi
+if [[ $skip_dep == false ]]; then
+  echo "executing helm dependencies setup"
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
 fi
 
 # Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd"
 
 if [[ $lint_microservices == true ]]; then
-  echo "Start linting microservices"
-  ALLOWED_MICROSERVICES=$(getAllowedMicroservicesForEnvironment "$ENV")
+    echo "Start linting microservices"
+    ALLOWED_MICROSERVICES=$(getAllowedMicroservicesForEnvironment "$ENV")
 
-  if [[ -z $ALLOWED_MICROSERVICES || $ALLOWED_MICROSERVICES == "" ]]; then
-    echo "No microservices found for environment '$ENV'. Skipping microservices linting."
-  fi
-
-  for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
-  do
-    echo "Linting $CURRENT_SVC"
-    VALID_CONFIG=$(isMicroserviceEnvConfigValid $CURRENT_SVC $ENV)
-    if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
-      echo "Environment configuration '$ENV' not found for microservice '$CURRENT_SVC'. Skip"
-    else
-      "$SCRIPTS_FOLDER"/helmLint-svc-single.sh -e $ENV -m $CURRENT_SVC $OPTIONS
+    if [[ -z $ALLOWED_MICROSERVICES || $ALLOWED_MICROSERVICES == "" ]]; then
+        echo "No microservices found for environment '$ENV'. Skipping microservices linting."
     fi
-  done
+
+    for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
+    do
+        echo "Linting $CURRENT_SVC"
+        VALID_CONFIG=$(isMicroserviceEnvConfigValid $CURRENT_SVC $ENV)
+        if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
+            echo "Environment configuration '$ENV' not found for microservice '$CURRENT_SVC'. Skip"
+        else
+            "$SCRIPTS_FOLDER"/helmLint-svc-single.sh -e $ENV -m $CURRENT_SVC $OPTIONS
+        fi
+    done
 fi
 
 if [[ $lint_jobs == true ]]; then
-  echo "Start linting cronjobs"
-  ALLOWED_CRONJOBS=$(getAllowedCronjobsForEnvironment "$ENV")
+    echo "Start linting cronjobs"
+    ALLOWED_CRONJOBS=$(getAllowedCronjobsForEnvironment "$ENV")
 
-  if [[ -z $ALLOWED_CRONJOBS || $ALLOWED_CRONJOBS == "" ]]; then
-    echo "No cronjobs found for environment '$ENV'. Skipping cronjobs linting."
-  fi
-
-  for CURRENT_JOB in ${ALLOWED_CRONJOBS//;/ }
-  do
-    echo "Linting $CURRENT_JOB"
-    VALID_CONFIG=$(isCronjobEnvConfigValid $CURRENT_JOB $ENV)
-    if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
-      echo "Environment configuration '$ENV' not found for cronjob '$CURRENT_JOB'"
-    else
-      "$SCRIPTS_FOLDER"/helmLint-cron-single.sh -e $ENV -j $CURRENT_JOB $OPTIONS
+    if [[ -z $ALLOWED_CRONJOBS || $ALLOWED_CRONJOBS == "" ]]; then
+        echo "No cronjobs found for environment '$ENV'. Skipping cronjobs linting."
     fi
-  done
+
+    for CURRENT_JOB in ${ALLOWED_CRONJOBS//;/ }
+    do
+        echo "Linting $CURRENT_JOB"
+        VALID_CONFIG=$(isCronjobEnvConfigValid $CURRENT_JOB $ENV)
+        if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
+            echo "Environment configuration '$ENV' not found for cronjob '$CURRENT_JOB'"
+        else
+      "$SCRIPTS_FOLDER"/helmLint-cron-single.sh -e $ENV -j $CURRENT_JOB $OPTIONS
+        fi
+    done
 fi
 
 if [[ $post_clean == true ]]; then
-  rm -rf "$ROOT_DIR/out/lint"
+    rm -rf "$ROOT_DIR/out/lint"
 fi

--- a/scripts/helm/helmLint-main.sh
+++ b/scripts/helm/helmLint-main.sh
@@ -128,7 +128,13 @@ if [[ -n $chart_path ]]; then
     OPTIONS=$OPTIONS" -cp $chart_path"
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
+  skip_dep=true
 fi
 
 # Skip further execution of helm deps build and update since we have already done it in the previous line

--- a/scripts/helm/helmLint-main.sh
+++ b/scripts/helm/helmLint-main.sh
@@ -68,7 +68,7 @@ do
           [[ "${2:-}" ]] || "When specified, output cannot be null" || help
           output_redirect=$2
           if [[ $output_redirect != "console" ]]; then
-             help
+            help
           fi
           step=2
           shift 2
@@ -98,11 +98,10 @@ do
           ;;
     esac
 done
-echo "Arguments: $@"
 
 if [[ -z $environment || $environment == "" ]]; then
-    echo "Environment cannot be null"
-    help
+  echo "Environment cannot be null"
+  help
 fi
 echo "Environment: $environment"
 
@@ -129,7 +128,6 @@ if [[ -n $chart_path ]]; then
     OPTIONS=$OPTIONS" -cp $chart_path"
 fi
 if [[ $skip_dep == false ]]; then
-  echo "executing helm dependencies setup"
   bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
 fi
 
@@ -137,43 +135,39 @@ fi
 OPTIONS=$OPTIONS" -sd"
 
 if [[ $lint_microservices == true ]]; then
-    echo "Start linting microservices"
-    ALLOWED_MICROSERVICES=$(getAllowedMicroservicesForEnvironment "$ENV")
-
-    if [[ -z $ALLOWED_MICROSERVICES || $ALLOWED_MICROSERVICES == "" ]]; then
-        echo "No microservices found for environment '$ENV'. Skipping microservices linting."
-    fi
-
-    for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
-    do
-        echo "Linting $CURRENT_SVC"
-        VALID_CONFIG=$(isMicroserviceEnvConfigValid $CURRENT_SVC $ENV)
-        if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
-            echo "Environment configuration '$ENV' not found for microservice '$CURRENT_SVC'. Skip"
-        else
-            "$SCRIPTS_FOLDER"/helmLint-svc-single.sh -e $ENV -m $CURRENT_SVC $OPTIONS
-        fi
-    done
+  echo "Start linting microservices"
+  ALLOWED_MICROSERVICES=$(getAllowedMicroservicesForEnvironment "$ENV")
+  if [[ -z $ALLOWED_MICROSERVICES || $ALLOWED_MICROSERVICES == "" ]]; then
+      echo "No microservices found for environment '$ENV'. Skipping microservices linting."
+  fi
+  for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
+  do
+      echo "Linting $CURRENT_SVC"
+      VALID_CONFIG=$(isMicroserviceEnvConfigValid $CURRENT_SVC $ENV)
+      if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
+          echo "Environment configuration '$ENV' not found for microservice '$CURRENT_SVC'. Skip"
+      else
+          "$SCRIPTS_FOLDER"/helmLint-svc-single.sh -e $ENV -m $CURRENT_SVC $OPTIONS
+      fi
+  done
 fi
 
 if [[ $lint_jobs == true ]]; then
-    echo "Start linting cronjobs"
-    ALLOWED_CRONJOBS=$(getAllowedCronjobsForEnvironment "$ENV")
-
-    if [[ -z $ALLOWED_CRONJOBS || $ALLOWED_CRONJOBS == "" ]]; then
-        echo "No cronjobs found for environment '$ENV'. Skipping cronjobs linting."
-    fi
-
-    for CURRENT_JOB in ${ALLOWED_CRONJOBS//;/ }
-    do
-        echo "Linting $CURRENT_JOB"
-        VALID_CONFIG=$(isCronjobEnvConfigValid $CURRENT_JOB $ENV)
-        if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
-            echo "Environment configuration '$ENV' not found for cronjob '$CURRENT_JOB'"
-        else
-      "$SCRIPTS_FOLDER"/helmLint-cron-single.sh -e $ENV -j $CURRENT_JOB $OPTIONS
-        fi
-    done
+  echo "Start linting cronjobs"
+  ALLOWED_CRONJOBS=$(getAllowedCronjobsForEnvironment "$ENV")
+  if [[ -z $ALLOWED_CRONJOBS || $ALLOWED_CRONJOBS == "" ]]; then
+      echo "No cronjobs found for environment '$ENV'. Skipping cronjobs linting."
+  fi
+  for CURRENT_JOB in ${ALLOWED_CRONJOBS//;/ }
+  do
+      echo "Linting $CURRENT_JOB"
+      VALID_CONFIG=$(isCronjobEnvConfigValid $CURRENT_JOB $ENV)
+      if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
+          echo "Environment configuration '$ENV' not found for cronjob '$CURRENT_JOB'"
+      else
+    "$SCRIPTS_FOLDER"/helmLint-cron-single.sh -e $ENV -j $CURRENT_JOB $OPTIONS
+      fi
+  done
 fi
 
 if [[ $post_clean == true ]]; then

--- a/scripts/helm/helmLint-svc-single.sh
+++ b/scripts/helm/helmLint-svc-single.sh
@@ -36,14 +36,12 @@ do
     case "$1" in
         -e| --environment )
           [[ "${2:-}" ]] || "Environment cannot be null" || help
-
           environment=$2
           step=2
           shift 2
           ;;
         -m | --microservice )
           [[ "${2:-}" ]] || "Microservice cannot be null" || help
-
           microservice=$2
           serviceAllowedRes=$(isAllowedMicroservice $microservice)
           if [[ -z $serviceAllowedRes || $serviceAllowedRes == "" ]]; then
@@ -51,13 +49,11 @@ do
             echo "Allowed values: " $(getAllowedMicroservices)
             help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -72,7 +68,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -98,7 +93,6 @@ do
         *)
           echo "Unexpected option: $1"
           help
-
           ;;
     esac
 done
@@ -148,7 +142,7 @@ OUTPUT_TO="> \"$OUT_DIR/$microservice.out.yaml\""
 if [[ $output_redirect == "console" ]]; then
   OUTPUT_TO=""
 fi
-
+#LINT_CMD=$LINT_CMD" \"$ROOT_DIR/charts/interop-eks-microservice-chart\" -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\" --set enableLookup=false $OUTPUT_TO"
 LINT_CMD+=" \"$ROOT_DIR/charts/interop-eks-microservice-chart\""
 LINT_CMD+=" -f \"$ROOT_DIR/commons/$ENV/values-microservice.compiled.yaml\""
 LINT_CMD+=" -f \"$ROOT_DIR/microservices/$microservice/$ENV/values.yaml\""

--- a/scripts/helm/helmLint-svc-single.sh
+++ b/scripts/helm/helmLint-svc-single.sh
@@ -15,7 +15,7 @@ help()
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print linting output on terminal
         [ -c | --clean ] Clean files and directories after script successfull execution
         [ -sd | --skip-dep ] Skip Helm dependencies setup
-        [ -cp | --chart-path ] Path to Chart.yaml (default: ./Chart.yaml)
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -87,7 +87,7 @@ do
           shift 1
           ;;
         -cp | --chart-path )
-          [[ "${2:-}" ]] || "When specified, chart path cannot be null" || help
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
           chart_path=$2
           step=2
           shift 2
@@ -112,7 +112,7 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path"
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
 fi
 
 VALID_CONFIG=$(isMicroserviceEnvConfigValid $microservice $environment)

--- a/scripts/helm/helmLint-svc-single.sh
+++ b/scripts/helm/helmLint-svc-single.sh
@@ -106,7 +106,13 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
+  skip_dep=true
 fi
 
 VALID_CONFIG=$(isMicroserviceEnvConfigValid $microservice $environment)

--- a/scripts/helm/helmTemplate-cron-single.sh
+++ b/scripts/helm/helmTemplate-cron-single.sh
@@ -37,29 +37,25 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
-              echo "$job is not allowed"
-              echo "Allowed values: " $(getAllowedCronjobs)
-              help
+            echo "$job is not allowed"
+            echo "Allowed values: " $(getAllowedCronjobs)
+            help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -74,7 +70,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -122,7 +117,13 @@ if [[ -z $job || $job == "" ]]; then
 fi
 
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
+  skip_dep=true
 fi
 
 VALID_CONFIG=$(isCronjobEnvConfigValid $job $environment)

--- a/scripts/helm/helmTemplate-cron-single.sh
+++ b/scripts/helm/helmTemplate-cron-single.sh
@@ -16,6 +16,7 @@ help()
         [ -c | --clean ] Clean files and directories after script successfull execution
         [ -v | --verbose ] Show debug messages
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -29,6 +30,7 @@ output_redirect=""
 skip_dep=false
 verbose=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -43,7 +45,7 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-          
+
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -57,7 +59,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -91,6 +93,12 @@ do
           step=1
           shift 1
           ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
+          ;;
         -h | --help )
           help
           ;;
@@ -102,6 +110,8 @@ do
     esac
 done
 
+ENV=$environment
+
 if [[ -z $environment || $environment == "" ]]; then
   echo "Environment cannot be null"
   help
@@ -110,8 +120,9 @@ if [[ -z $job || $job == "" ]]; then
   echo "Job cannot null"
   help
 fi
+
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
 fi
 
 VALID_CONFIG=$(isCronjobEnvConfigValid $job $environment)
@@ -120,7 +131,6 @@ if [[ -z $VALID_CONFIG || $VALID_CONFIG == "" ]]; then
   help
 fi
 
-ENV=$environment
 JOB_DIR=$( echo $job | sed  's/-/_/g' )
 OUT_DIR="$ROOT_DIR/out/templates/$ENV/job_$JOB_DIR"
 if [[ $output_redirect != "console" ]]; then

--- a/scripts/helm/helmTemplate-main.sh
+++ b/scripts/helm/helmTemplate-main.sh
@@ -136,7 +136,12 @@ if [[ -n $chart_path ]]; then
 fi
 
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
 fi
 
 MICROSERVICE_OPTIONS=" "

--- a/scripts/helm/helmTemplate-main.sh
+++ b/scripts/helm/helmTemplate-main.sh
@@ -18,6 +18,7 @@ help()
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print template output on terminal
         [ -c | --clean ] Clean files and directories after scripts successfull execution
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -dtl | --disable-templating-lookup ] Disable Helm --dry-run=server option in order to avoid lookup configmaps and secrets when templating
         [ -h | --help ] This help"
     exit 2
@@ -33,6 +34,7 @@ output_redirect=""
 skip_dep=false
 disable_templating_lookup=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -57,7 +59,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -90,6 +92,12 @@ do
           disable_templating_lookup=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -125,25 +133,30 @@ fi
 if [[ -n $images_file ]]; then
   OPTIONS=$OPTIONS" -i $images_file"
 fi
+
+if [[ -n $chart_path ]]; then
+  OPTIONS=$OPTIONS" -cp $chart_path"
+fi
+
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
 fi
 
 MICROSERVICE_OPTIONS=" "
 if [[ $disable_templating_lookup != true ]]; then
   MICROSERVICE_OPTIONS=$MICROSERVICE_OPTIONS" --enable-templating-lookup"
 fi
-# Skip further execution of helm deps build and update since we have already done it in the previous line 
+# Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd"
 
 if [[ $template_microservices == true ]]; then
   echo "Start microservices templates generation"
   ALLOWED_MICROSERVICES=$(getAllowedMicroservicesForEnvironment "$ENV")
-  
+
   if [[ -z $ALLOWED_MICROSERVICES || $ALLOWED_MICROSERVICES == "" ]]; then
     echo "No microservices found for environment '$ENV'. Skipping microservices templates generation."
   fi
-  
+
   for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
   do
     echo "Templating $CURRENT_SVC"
@@ -160,11 +173,11 @@ fi
 if [[ $template_jobs == true ]]; then
   echo "Start cronjobs templates generation"
   ALLOWED_CRONJOBS=$(getAllowedCronjobsForEnvironment "$ENV")
-  
+
   if [[ -z $ALLOWED_CRONJOBS || $ALLOWED_CRONJOBS == "" ]]; then
     echo "No cronjobs found for environment '$ENV'. Skipping cronjobs templates generation."
   fi
-  
+
   for CURRENT_JOB in ${ALLOWED_CRONJOBS//;/ }
   do
     echo "Templating $CURRENT_JOB"

--- a/scripts/helm/helmTemplate-main.sh
+++ b/scripts/helm/helmTemplate-main.sh
@@ -41,8 +41,7 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
@@ -59,7 +58,6 @@ do
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -74,7 +72,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;

--- a/scripts/helm/helmTemplate-svc-single.sh
+++ b/scripts/helm/helmTemplate-svc-single.sh
@@ -120,7 +120,12 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
 fi
 
 VALID_CONFIG=$(isMicroserviceEnvConfigValid $microservice $environment)

--- a/scripts/helm/helmTemplate-svc-single.sh
+++ b/scripts/helm/helmTemplate-svc-single.sh
@@ -39,15 +39,13 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
           ;;
         -m | --microservice )
           [[ "${2:-}" ]] || "Microservice cannot be null" || help
-
           microservice=$2
           serviceAllowedRes=$(isAllowedMicroservice $microservice)
           if [[ -z $serviceAllowedRes || $serviceAllowedRes == "" ]]; then
@@ -55,13 +53,11 @@ do
             echo "Allowed values: " $(getAllowedMicroservices)
             help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -76,7 +72,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -112,7 +107,6 @@ do
         *)
           echo "Unexpected option: $1"
           help
-
           ;;
     esac
 done

--- a/scripts/helm/helmUpgrade-cron-single-standalone.sh
+++ b/scripts/helm/helmUpgrade-cron-single-standalone.sh
@@ -42,8 +42,7 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
@@ -65,7 +64,6 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -73,13 +71,11 @@ do
               echo "Allowed values: " $(getAllowedCronjobs)
               help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -89,7 +85,6 @@ do
           if [[ $output_redirect != "console" && $output_redirect != "null" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -105,7 +100,6 @@ do
             echo "History-max must be equal or greater than 0"
             help
           fi
-
           step=2
           shift 2
           ;;

--- a/scripts/helm/helmUpgrade-cron-single-standalone.sh
+++ b/scripts/helm/helmUpgrade-cron-single-standalone.sh
@@ -134,7 +134,12 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/helmUpgrade-cron-single-standalone.sh
+++ b/scripts/helm/helmUpgrade-cron-single-standalone.sh
@@ -11,13 +11,14 @@ help()
     echo "Usage:  [ -e | --environment ] Cluster environment used to execute helm upgrade
         [ -dr | --dry-run ] Enable dry-run mode
         [ -d | --debug ] Enable debug
-        [ -a | --atomic ] Enable helm install atomic option 
+        [ -a | --atomic ] Enable helm install atomic option
         [ -j | --job ] Cronjob defined in jobs folder
         [ -i | --image ] File with cronjob image tag and digest
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print template output on terminal or "null" to redirect output to /dev/null
         [ -sd | --skip-dep ] Skip Helm dependencies setup
         [ -hm | --history-max ] Set the maximum number of revisions saved per release
         [ --force ] Force helm upgrade
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -34,6 +35,7 @@ skip_dep=false
 images_file=""
 force=false
 history_max=3
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -63,7 +65,7 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-          
+
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -77,7 +79,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -112,6 +114,12 @@ do
           step=1
           shift 1
           ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
+          ;;
         -h | --help )
           help
           ;;
@@ -132,7 +140,7 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
 

--- a/scripts/helm/helmUpgrade-main.sh
+++ b/scripts/helm/helmUpgrade-main.sh
@@ -50,8 +50,7 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
@@ -78,7 +77,6 @@ do
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -88,7 +86,6 @@ do
           if [[ $output_redirect != "console" && $output_redirect != "null" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -104,7 +101,6 @@ do
             echo "History-max must be equal or greater than 0"
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -121,7 +117,6 @@ do
         -t | --timeout)
           [[ "${2:-}" ]] || "When specified, timeout cannot be null" || help
           timeout=$2
-
           step=2
           shift 2
           ;;

--- a/scripts/helm/helmUpgrade-main.sh
+++ b/scripts/helm/helmUpgrade-main.sh
@@ -176,7 +176,12 @@ if [[ -n $chart_path ]]; then
 fi
 
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
 fi
 # Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd -hm $history_max"

--- a/scripts/helm/helmUpgrade-main.sh
+++ b/scripts/helm/helmUpgrade-main.sh
@@ -12,7 +12,7 @@ help()
 {
     echo "Usage:  [ -e | --environment ] Environment used to execute helm upgrade
         [ -d | --debug ] Enable debug
-        [ -a | --atomic ] Enable helm install atomic option 
+        [ -a | --atomic ] Enable helm install atomic option
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print template output on terminal or "null" to redirect output to /dev/null
         [ -m | --microservices ] Execute diff for all microservices
         [ -j | --jobs ] Execute diff for all cronjobs
@@ -22,6 +22,7 @@ help()
         [ -nw | --no-wait ] Do not wait for the release to be ready
         [ -t | --timeout ] Set the timeout for the upgrade operation (default is 5m0s)
         [ --force ] Force helm upgrade
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -dtl | --disable-templating-lookup ] Disable Helm --dry-run=server option in order to avoid lookup configmaps and secrets when upgrading
         [ -h | --help ] This help"
     exit 2
@@ -42,6 +43,7 @@ history_max=3
 wait=true
 timeout="5m0s"
 disable_templating_lookup=false
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -76,7 +78,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -119,7 +121,7 @@ do
         -t | --timeout)
           [[ "${2:-}" ]] || "When specified, timeout cannot be null" || help
           timeout=$2
-          
+
           step=2
           shift 2
           ;;
@@ -127,6 +129,12 @@ do
           disable_templating_lookup=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -168,18 +176,21 @@ fi
 if [[ -n $images_file ]]; then
   OPTIONS=$OPTIONS" -i $images_file"
 fi
-if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
-  skip_dep=true
+if [[ -n $chart_path ]]; then
+  OPTIONS=$OPTIONS" -cp $chart_path"
 fi
-# Skip further execution of helm deps build and update since we have already done it in the previous line 
+
+if [[ $skip_dep == false ]]; then
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+fi
+# Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd -hm $history_max"
 
 MICROSERVICE_OPTIONS=" "
 if [[ $wait == true ]]; then
   MICROSERVICE_OPTIONS=$MICROSERVICE_OPTIONS" --timeout $timeout"
 else
-  MICROSERVICE_OPTIONS=$MICROSERVICE_OPTIONS" --no-wait" 
+  MICROSERVICE_OPTIONS=$MICROSERVICE_OPTIONS" --no-wait"
 fi
 if [[ $disable_templating_lookup == true ]]; then
   MICROSERVICE_OPTIONS=$MICROSERVICE_OPTIONS" --disable-templating-lookup"
@@ -188,11 +199,11 @@ fi
 if [[ $template_microservices == true ]]; then
   echo "[MAIN-UPGRADE] Start microservices helm install"
   ALLOWED_MICROSERVICES=$(getAllowedMicroservicesForEnvironment "$ENV")
-  
+
   if [[ -z $ALLOWED_MICROSERVICES || $ALLOWED_MICROSERVICES == "" ]]; then
     echo "[MAIN-UPGRADE] No microservices found for environment '$ENV'. Skipping microservices upgrade."
   fi
-  
+
   for CURRENT_SVC in ${ALLOWED_MICROSERVICES//;/ }
   do
     echo "[MAIN-UPGRADE] Upgrade $CURRENT_SVC"
@@ -203,11 +214,11 @@ fi
 if [[ $template_jobs == true ]]; then
   echo "[MAIN-UPGRADE] Start cronjobs helm install"
   ALLOWED_CRONJOBS=$(getAllowedCronjobsForEnvironment "$ENV")
-  
+
   if [[ -z $ALLOWED_CRONJOBS || $ALLOWED_CRONJOBS == "" ]]; then
     echo "[MAIN-UPGRADE] No cronjobs found for environment '$ENV'. Skipping cronjobs upgrade."
   fi
-  
+
   for CURRENT_JOB in ${ALLOWED_CRONJOBS//;/ }
   do
     echo "[MAIN-UPGRADE] Upgrade $CURRENT_JOB"

--- a/scripts/helm/helmUpgrade-svc-single-standalone.sh
+++ b/scripts/helm/helmUpgrade-svc-single-standalone.sh
@@ -10,7 +10,7 @@ help()
 {
     echo "Usage:  [ -e | --environment ] Cluster environment used to execute helm upgrade
         [ -d | --debug ] Enable debug
-        [ -a | --atomic ] Enable helm install atomic option 
+        [ -a | --atomic ] Enable helm install atomic option
         [ -m | --microservice ] Microservice defined in microservices folder
         [ -i | --image ] File with microservice image tag and digest
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print template output on terminal or "null" to redirect output to /dev/null
@@ -19,6 +19,7 @@ help()
         [ -nw | --no-wait ] Do not wait for the release to be ready
         [ -t | --timeout ] Set the timeout for the upgrade operation (default is 5m0s)
         [ --force ] Force helm upgrade
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -dtl | --disable-templating-lookup ] Disable Helm --dry-run=server option in order to avoid lookup configmaps and secrets when upgrading
         [ -h | --help ] This help"
     exit 2
@@ -38,6 +39,7 @@ history_max=3
 wait=true
 timeout="5m0s"
 disable_templating_lookup=false
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -76,7 +78,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -119,7 +121,7 @@ do
         -t | --timeout)
           [[ "${2:-}" ]] || "When specified, timeout cannot be null" || help
           timeout=$2
-          
+
           step=2
           shift 2
           ;;
@@ -127,6 +129,12 @@ do
           disable_templating_lookup=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -148,7 +156,7 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
 

--- a/scripts/helm/helmUpgrade-svc-single-standalone.sh
+++ b/scripts/helm/helmUpgrade-svc-single-standalone.sh
@@ -46,8 +46,7 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
@@ -64,7 +63,6 @@ do
           ;;
         -m | --microservice )
           [[ "${2:-}" ]] || "Microservice cannot be null" || help
-
           microservice=$2
           serviceAllowedRes=$(isAllowedMicroservice $microservice)
           if [[ -z $serviceAllowedRes || $serviceAllowedRes == "" ]]; then
@@ -72,13 +70,11 @@ do
             echo "Allowed values: " $(getAllowedMicroservices)
             help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -88,7 +84,6 @@ do
           if [[ $output_redirect != "console" && $output_redirect != "null" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -104,7 +99,6 @@ do
             echo "History-max must be equal or greater than 0"
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -121,7 +115,6 @@ do
         -t | --timeout)
           [[ "${2:-}" ]] || "When specified, timeout cannot be null" || help
           timeout=$2
-
           step=2
           shift 2
           ;;

--- a/scripts/helm/helmUpgrade-svc-single-standalone.sh
+++ b/scripts/helm/helmUpgrade-svc-single-standalone.sh
@@ -149,7 +149,12 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlApply-cron-single-standalone.sh
+++ b/scripts/helm/kubectlApply-cron-single-standalone.sh
@@ -34,8 +34,7 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
@@ -47,7 +46,6 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -55,13 +53,11 @@ do
               echo "Allowed values: " $(getAllowedCronjobs)
               help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -71,7 +67,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -92,7 +87,6 @@ do
         *)
           echo "Unexpected option: $1"
           help
-
           ;;
     esac
 done

--- a/scripts/helm/kubectlApply-cron-single-standalone.sh
+++ b/scripts/helm/kubectlApply-cron-single-standalone.sh
@@ -100,7 +100,12 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlApply-cron-single-standalone.sh
+++ b/scripts/helm/kubectlApply-cron-single-standalone.sh
@@ -14,6 +14,7 @@ help()
         [ -i | --image ] File with cronjob image tag and digest
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print template output on terminal
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -26,6 +27,7 @@ post_clean=false
 output_redirect=""
 skip_dep=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -45,7 +47,7 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-          
+
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -59,7 +61,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -77,6 +79,12 @@ do
           skip_dep=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -98,7 +106,7 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlApply-main.sh
+++ b/scripts/helm/kubectlApply-main.sh
@@ -17,6 +17,7 @@ help()
         [ -j | --jobs ] Execute diff for all cronjobs
         [ -i | --image ] File with microservices and cronjobs images tag and digest
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -30,6 +31,7 @@ post_clean=false
 output_redirect=""
 skip_dep=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -59,7 +61,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -77,6 +79,12 @@ do
           skip_dep=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -112,11 +120,13 @@ fi
 if [[ -n $images_file ]]; then
   OPTIONS=$OPTIONS" -i $images_file"
 fi
-if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
-  skip_dep=true
+if [[ -n $chart_path ]]; then
+  OPTIONS=$OPTIONS" -cp $chart_path"
 fi
-# Skip further execution of helm deps build and update since we have already done it in the previous line 
+if [[ $skip_dep == false ]]; then
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+fi
+# Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd"
 
 if [[ $template_microservices == true ]]; then

--- a/scripts/helm/kubectlApply-main.sh
+++ b/scripts/helm/kubectlApply-main.sh
@@ -121,7 +121,12 @@ if [[ -n $chart_path ]]; then
   OPTIONS=$OPTIONS" -cp $chart_path"
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 # Skip further execution of helm deps build and update since we have already done it in the previous line

--- a/scripts/helm/kubectlApply-main.sh
+++ b/scripts/helm/kubectlApply-main.sh
@@ -122,6 +122,7 @@ if [[ -n $chart_path ]]; then
 fi
 if [[ $skip_dep == false ]]; then
   bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+  skip_dep=true
 fi
 # Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd"

--- a/scripts/helm/kubectlApply-main.sh
+++ b/scripts/helm/kubectlApply-main.sh
@@ -39,7 +39,6 @@ do
     case "$1" in
         -e| --environment )
             [[ "${2:-}" ]] || "Environment cannot be null" || help
-
           environment=$2
           step=2
           shift 2
@@ -61,7 +60,6 @@ do
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -71,7 +69,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;

--- a/scripts/helm/kubectlApply-svc-single-standalone.sh
+++ b/scripts/helm/kubectlApply-svc-single-standalone.sh
@@ -15,6 +15,7 @@ help()
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print template output on terminal
         [ -sd | --skip-dep ] Skip Helm dependencies setup
         [ -dtl | --disable-templating-lookup ] Disable Helm --dry-run=server option in order to avoid lookup configmaps and secrets when templating
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -28,6 +29,7 @@ output_redirect=""
 skip_dep=false
 disable_templating_lookup=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -61,7 +63,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -85,6 +87,12 @@ do
           step=1
           shift 1
           ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
+          ;;
         -h | --help )
           help
           ;;
@@ -105,7 +113,7 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlApply-svc-single-standalone.sh
+++ b/scripts/helm/kubectlApply-svc-single-standalone.sh
@@ -108,7 +108,12 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlApply-svc-single-standalone.sh
+++ b/scripts/helm/kubectlApply-svc-single-standalone.sh
@@ -36,8 +36,7 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
@@ -49,7 +48,6 @@ do
           ;;
         -m | --microservice )
           [[ "${2:-}" ]] || "Microservice cannot be null" || help
-
           microservice=$2
           serviceAllowedRes=$(isAllowedMicroservice $microservice)
           if [[ -z $serviceAllowedRes || $serviceAllowedRes == "" ]]; then
@@ -57,13 +55,11 @@ do
             echo "Allowed values: " $(getAllowedMicroservices)
             help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -73,7 +69,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;

--- a/scripts/helm/kubectlDiff-cron-single-fromdir.sh
+++ b/scripts/helm/kubectlDiff-cron-single-fromdir.sh
@@ -11,6 +11,7 @@ help()
     echo "Usage:  [ -e | --environment ] Cluster environment used to execute kubectl diff
         [ -j | --job ] Cronjob defined in jobs folder
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -21,6 +22,7 @@ job=""
 enable_debug=false
 post_clean=false
 skip_dep=false
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -35,7 +37,7 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-          
+
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -51,6 +53,12 @@ do
           skip_dep=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -72,7 +80,7 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash $(dirname "$0")/helmDep.sh
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
 fi
 
 VALID_CONFIG=$(isCronjobEnvConfigValid $job $environment)

--- a/scripts/helm/kubectlDiff-cron-single-fromdir.sh
+++ b/scripts/helm/kubectlDiff-cron-single-fromdir.sh
@@ -76,7 +76,12 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
 fi
 
 VALID_CONFIG=$(isCronjobEnvConfigValid $job $environment)

--- a/scripts/helm/kubectlDiff-cron-single-fromdir.sh
+++ b/scripts/helm/kubectlDiff-cron-single-fromdir.sh
@@ -30,14 +30,12 @@ do
     case "$1" in
         -e| --environment )
             [[ "${2:-}" ]] || "Environment cannot be null" || help
-
           environment=$2
           step=2
           shift 2
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -45,7 +43,6 @@ do
               echo "Allowed values: " $(getAllowedCronjobs)
               help
           fi
-
           step=2
           shift 2
           ;;
@@ -66,7 +63,6 @@ do
         *)
           echo "Unexpected option: $1"
           help
-
           ;;
     esac
 done

--- a/scripts/helm/kubectlDiff-cron-single-standalone.sh
+++ b/scripts/helm/kubectlDiff-cron-single-standalone.sh
@@ -35,7 +35,6 @@ do
     case "$1" in
         -e| --environment )
             [[ "${2:-}" ]] || "Environment cannot be null" || help
-
           environment=$2
           step=2
           shift 2
@@ -47,7 +46,6 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -55,13 +53,11 @@ do
               echo "Allowed values: " $(getAllowedCronjobs)
               help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -71,7 +67,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -92,7 +87,6 @@ do
         *)
           echo "Unexpected option: $1"
           help
-
           ;;
     esac
 done

--- a/scripts/helm/kubectlDiff-cron-single-standalone.sh
+++ b/scripts/helm/kubectlDiff-cron-single-standalone.sh
@@ -101,7 +101,12 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlDiff-cron-single-standalone.sh
+++ b/scripts/helm/kubectlDiff-cron-single-standalone.sh
@@ -14,6 +14,7 @@ help()
         [ -i | --image ] File with cronjob image tag and digest
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print template output on terminal
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -26,6 +27,7 @@ post_clean=false
 output_redirect=""
 skip_dep=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -45,7 +47,7 @@ do
           ;;
         -j | --job )
           [[ "${2:-}" ]] || "Job cannot be null" || help
-          
+
           job=$2
           jobAllowedRes=$(isAllowedCronjob $job)
           if [[ -z $jobAllowedRes || $jobAllowedRes == "" ]]; then
@@ -59,7 +61,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -77,6 +79,12 @@ do
           skip_dep=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -99,7 +107,7 @@ if [[ -z $job || $job == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlDiff-main-fromdir.sh
+++ b/scripts/helm/kubectlDiff-main-fromdir.sh
@@ -15,6 +15,7 @@ help()
         [ -j | --jobs ] Execute diff for all cronjobs
         [ -i | --image ] File with microservices and cronjobs images tag and digest
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -27,6 +28,7 @@ template_jobs=false
 post_clean=false
 skip_dep=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -51,7 +53,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -59,6 +61,12 @@ do
           skip_dep=true
           step=1
           shift 1
+          ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
           ;;
         -h | --help )
           help
@@ -91,10 +99,13 @@ fi
 if [[ -n $images_file ]]; then
   OPTIONS=$OPTIONS" -i $images_file"
 fi
-if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+if [[ -n $chart_path ]]; then
+  OPTIONS=$OPTIONS" -cp $chart_path"
 fi
-# Skip further execution of helm deps build and update since we have already done it in the previous line 
+if [[ $skip_dep == false ]]; then
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+fi
+# Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd"
 
 if [[ $template_microservices == true ]]; then

--- a/scripts/helm/kubectlDiff-main-fromdir.sh
+++ b/scripts/helm/kubectlDiff-main-fromdir.sh
@@ -101,7 +101,12 @@ if [[ -n $chart_path ]]; then
   OPTIONS=$OPTIONS" -cp $chart_path"
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
 fi
 # Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd"

--- a/scripts/helm/kubectlDiff-main-fromdir.sh
+++ b/scripts/helm/kubectlDiff-main-fromdir.sh
@@ -35,8 +35,7 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
@@ -53,7 +52,6 @@ do
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;

--- a/scripts/helm/kubectlDiff-main-standalone.sh
+++ b/scripts/helm/kubectlDiff-main-standalone.sh
@@ -129,7 +129,12 @@ if [[ -n $chart_path ]]; then
 fi
 
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 # Skip further execution of helm deps build and update since we have already done it in the previous line

--- a/scripts/helm/kubectlDiff-main-standalone.sh
+++ b/scripts/helm/kubectlDiff-main-standalone.sh
@@ -41,7 +41,6 @@ do
     case "$1" in
         -e| --environment )
             [[ "${2:-}" ]] || "Environment cannot be null" || help
-
           environment=$2
           step=2
           shift 2
@@ -63,7 +62,6 @@ do
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -73,7 +71,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;

--- a/scripts/helm/kubectlDiff-main-standalone.sh
+++ b/scripts/helm/kubectlDiff-main-standalone.sh
@@ -130,6 +130,7 @@ fi
 
 if [[ $skip_dep == false ]]; then
   bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --chart-path "$chart_path" --environment "$ENV"
+  skip_dep=true
 fi
 # Skip further execution of helm deps build and update since we have already done it in the previous line
 OPTIONS=$OPTIONS" -sd"

--- a/scripts/helm/kubectlDiff-svc-single-fromdir.sh
+++ b/scripts/helm/kubectlDiff-svc-single-fromdir.sh
@@ -75,7 +75,12 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlDiff-svc-single-fromdir.sh
+++ b/scripts/helm/kubectlDiff-svc-single-fromdir.sh
@@ -29,14 +29,12 @@ do
     case "$1" in
         -e| --environment )
             [[ "${2:-}" ]] || "Environment cannot be null" || help
-
           environment=$2
           step=2
           shift 2
           ;;
         -m | --microservice )
           [[ "${2:-}" ]] || "Microservice cannot be null" || help
-
           microservice=$2
           serviceAllowedRes=$(isAllowedMicroservice $microservice)
           if [[ -z $serviceAllowedRes || $serviceAllowedRes == "" ]]; then
@@ -44,7 +42,6 @@ do
             echo "Allowed values: " $(getAllowedMicroservices)
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -65,7 +62,6 @@ do
         *)
           echo "Unexpected option: $1"
           help
-
           ;;
     esac
 done

--- a/scripts/helm/kubectlDiff-svc-single-fromdir.sh
+++ b/scripts/helm/kubectlDiff-svc-single-fromdir.sh
@@ -11,6 +11,7 @@ help()
     echo "Usage:  [ -e | --environment ] Cluster environment used to execute kubectl diff
         [ -m | --microservice ] Microservice defined in microservices folder
         [ -sd | --skip-dep ] Skip Helm dependencies setup
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -20,6 +21,7 @@ environment=""
 microservice=""
 enable_debug=false
 post_clean=false
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -51,6 +53,12 @@ do
           step=1
           shift 1
           ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
+          ;;
         -h | --help )
           help
           ;;
@@ -71,7 +79,7 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
 
@@ -98,4 +106,3 @@ eval $DIFF_CMD
 #if [[ $post_clean == true ]]; then
 #  rm -rf $OUT_DIR
 #fi
-

--- a/scripts/helm/kubectlDiff-svc-single-standalone.sh
+++ b/scripts/helm/kubectlDiff-svc-single-standalone.sh
@@ -15,6 +15,7 @@ help()
         [ -o | --output ] Default output to predefined dir. Otherwise set to "console" to print template output on terminal
         [ -sd | --skip-dep ] Skip Helm dependencies setup
         [ -dtl | --disable-templating-lookup ] Disable Helm --dry-run=server option in order to avoid lookup configmaps and secrets when templating
+        [ -cp | --chart-path ] Path to Chart.yaml file (overrides environment selection; must be an existing file)
         [ -h | --help ] This help"
     exit 2
 }
@@ -28,6 +29,7 @@ output_redirect=""
 skip_dep=false
 disable_templating_lookup=false
 images_file=""
+chart_path=""
 
 step=1
 for (( i=0; i<$args; i+=$step ))
@@ -61,7 +63,7 @@ do
           ;;
         -i | --image )
           images_file=$2
-          
+
           step=2
           shift 2
           ;;
@@ -85,6 +87,12 @@ do
           step=1
           shift 1
           ;;
+        -cp | --chart-path )
+          [[ "${2:-}" ]] || { echo "Error: The chart path (-cp/--chart-path) cannot be null or empty."; help; }
+          chart_path=$2
+          step=2
+          shift 2
+          ;;
         -h | --help )
           help
           ;;
@@ -105,7 +113,7 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar
+  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlDiff-svc-single-standalone.sh
+++ b/scripts/helm/kubectlDiff-svc-single-standalone.sh
@@ -107,7 +107,12 @@ if [[ -z $microservice || $microservice == "" ]]; then
   help
 fi
 if [[ $skip_dep == false ]]; then
-  bash "$SCRIPTS_FOLDER"/helmDep.sh --untar --verbose --chart-path "$chart_path" --environment "$environment"
+  HELMDEP_OPTIONS="--untar"
+  if [[ -n "$chart_path" ]]; then
+    HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --chart-path "$chart_path""
+  fi
+  HELMDEP_OPTIONS+="$HELMDEP_OPTIONS --environment "$environment""
+  bash "$SCRIPTS_FOLDER"/helmDep.sh $HELMDEP_OPTIONS
   skip_dep=true
 fi
 

--- a/scripts/helm/kubectlDiff-svc-single-standalone.sh
+++ b/scripts/helm/kubectlDiff-svc-single-standalone.sh
@@ -36,8 +36,7 @@ for (( i=0; i<$args; i+=$step ))
 do
     case "$1" in
         -e| --environment )
-            [[ "${2:-}" ]] || "Environment cannot be null" || help
-
+          [[ "${2:-}" ]] || "Environment cannot be null" || help
           environment=$2
           step=2
           shift 2
@@ -49,7 +48,6 @@ do
           ;;
         -m | --microservice )
           [[ "${2:-}" ]] || "Microservice cannot be null" || help
-
           microservice=$2
           serviceAllowedRes=$(isAllowedMicroservice $microservice)
           if [[ -z $serviceAllowedRes || $serviceAllowedRes == "" ]]; then
@@ -57,13 +55,11 @@ do
             echo "Allowed values: " $(getAllowedMicroservices)
             help
           fi
-
           step=2
           shift 2
           ;;
         -i | --image )
           images_file=$2
-
           step=2
           shift 2
           ;;
@@ -73,7 +69,6 @@ do
           if [[ $output_redirect != "console" ]]; then
             help
           fi
-
           step=2
           shift 2
           ;;
@@ -99,7 +94,6 @@ do
         *)
           echo "Unexpected option: $1"
           help
-
           ;;
     esac
 done


### PR DESCRIPTION
This PR introduces the following changes:

* **Chart.yaml management:**
  Chart.yaml files must now be present in each environment folder (e.g. commons/$ENV/Chart.yaml); it will be no longer possible to use a Chart.yaml file in the project root folder.

* **New flag for Chart.yaml override:**
  All scripts now support the `--chart-path` (`-cp`) flag, which allows to override the environment by specifying a custom path to the `Chart.yaml` file.

* **Scripts refactoring for input validation and error handling:**
  At least one of `--environment` (`-e`) or `--chart-path` (`-cp`) must be provided.

* **Improved file validation:**
  The script now checks that `Chart.yaml` exists and is a regular file. If it is not present, an error will be raised.