### PR TITLE
fix(postgresql-user module): add PATH_TO_SCRIPTS env when executing external file to create view, add UUID suffix to generate_user_grant_revoke_ddl view

### DIFF
--- a/terraform/modules/postgresql-user/20-sql.tf
+++ b/terraform/modules/postgresql-user/20-sql.tf
@@ -115,6 +115,7 @@ resource "terraform_data" "delete_previous_role" {
       ADMIN_CREDENTIALS_SECRET_ARN = self.input.db_admin_credentials_secret_arn
       USERNAME                     = self.triggers_replace[0]
       CURRENT_USERNAME             = self.input.username
+      PATH_TO_SCRIPTS              = self.input.path_to_scripts
     }
 
     command = <<EOT
@@ -170,6 +171,7 @@ resource "terraform_data" "delete_role" {
       HOST                         = self.input.db_host
       SCHEMA_NAME                  = self.input.redshift_schema_name
       ADMIN_CREDENTIALS_SECRET_ARN = self.input.db_admin_credentials_secret_arn
+      PATH_TO_SCRIPTS              = self.input.path_to_scripts
     }
 
     command = <<EOT

--- a/terraform/modules/postgresql-user/scripts/redshift/delete_role.sql
+++ b/terraform/modules/postgresql-user/scripts/redshift/delete_role.sql
@@ -2,7 +2,8 @@ CREATE SCHEMA IF NOT EXISTS ${SCHEMA_NAME};
 
 -- Execute external file to create or update a view containing revoke commands for the users
 \set schema_name ${SCHEMA_NAME}
-\i ./v_generate_user_grant_revoke_ddl.sql
+\set uuid ${UUID}
+\i '${PATH_TO_SCRIPTS}/v_generate_user_grant_revoke_ddl.sql'
 
 -- Create a procedure to revoke all the privileges of the target_user and, then, to drop it 
 CREATE OR REPLACE PROCEDURE ${SCHEMA_NAME}.drop_user_with_revoke_${UUID}(target_user VARCHAR)
@@ -18,7 +19,7 @@ BEGIN
 -- Revokes privileges of the target_user
       FOR rec IN 
           SELECT ddl 
-          FROM ${SCHEMA_NAME}.v_generate_user_grant_revoke_ddl
+          FROM ${SCHEMA_NAME}.v_generate_user_grant_revoke_ddl_${UUID}
           WHERE grantee = target_user 
           AND ddltype = 'revoke'
           ORDER BY grantseq ASC
@@ -41,3 +42,6 @@ CALL ${SCHEMA_NAME}.drop_user_with_revoke_${UUID}('${USERNAME}');
 
 -- Drop the procedure
 DROP PROCEDURE ${SCHEMA_NAME}.drop_user_with_revoke_${UUID}(VARCHAR);
+
+-- Drop the view
+DROP VIEW IF EXISTS ${SCHEMA_NAME}.v_generate_user_grant_revoke_ddl_${UUID};

--- a/terraform/modules/postgresql-user/scripts/redshift/v_generate_user_grant_revoke_ddl.sql
+++ b/terraform/modules/postgresql-user/scripts/redshift/v_generate_user_grant_revoke_ddl.sql
@@ -1,7 +1,7 @@
 -- Reference: https://github.com/awslabs/amazon-redshift-utils/blob/master/src/AdminViews/v_generate_user_grant_revoke_ddl.sql
 -- A fix has been applied to row 184: function replace() helps in removing double quotes from the object name, otherwise there will be a syntax error.
 
-CREATE OR REPLACE VIEW :schema_name.v_generate_user_grant_revoke_ddl AS
+CREATE OR REPLACE VIEW :schema_name.v_generate_user_grant_revoke_ddl_:uuid AS
 WITH objprivs AS ( 
 SELECT objowner, 
       schemaname, 


### PR DESCRIPTION
Adding the `PATH_TO_SCRIPTS` env when executing external file to create the `generate_user_grant_revoke_ddl` view is necessary otherwise you will get: 
> v_generate_user_grant_revoke_ddl.sql: No such file or directory

Adding the UUID suffix to the `generate_user_grant_revoke_ddl` view name is necessary to avoid conflicts when deleting several user at the same time using the same module, otherwise you will get: 

> ERROR:  duplicate key violates unique constraint "pg_class_relname_nsp_index" (possibly caused by concurrent transaction conflict) 