### PR TITLE
fix(postgresql-user module): add file lock when executing additional sql statements

### DIFF
--- a/terraform/modules/postgresql-user/20-sql.tf
+++ b/terraform/modules/postgresql-user/20-sql.tf
@@ -72,15 +72,22 @@ resource "terraform_data" "additional_script" {
     command = <<EOT
       #!/bin/bash
       set -euo pipefail
-      
-      secret_json=$(aws secretsmanager get-secret-value --secret-id $ADMIN_CREDENTIALS_SECRET_ARN --query SecretString --output text)
 
-      ADMIN_USERNAME=$(echo $secret_json | jq -r '.username')
-      ADMIN_PASSWORD=$(echo $secret_json | jq -r '.password')
+      LOCK_FILE="/tmp/redshift_postgresql_user_module_additional_statements_sql_lock"
 
-      export PGPASSWORD=$ADMIN_PASSWORD
+      (
+        flock -x 200
+          
+        secret_json=$(aws secretsmanager get-secret-value --secret-id $ADMIN_CREDENTIALS_SECRET_ARN --query SecretString --output text)
 
-      psql -h "$HOST" -U "$ADMIN_USERNAME" -d "$DATABASE" -p "$DATABASE_PORT" -c "${var.additional_sql_statements}"
+        ADMIN_USERNAME=$(echo $secret_json | jq -r '.username')
+        ADMIN_PASSWORD=$(echo $secret_json | jq -r '.password')
+
+        export PGPASSWORD=$ADMIN_PASSWORD
+
+        psql -h "$HOST" -U "$ADMIN_USERNAME" -d "$DATABASE" -p "$DATABASE_PORT" -c "${var.additional_sql_statements}"
+
+      ) 200>"$LOCK_FILE"
     EOT
   }
 }


### PR DESCRIPTION
_Issue_:
When creating several users using the same `postgresql-user` module with additional sql statements, you will get error due to concurrency problems.

From Amazon Redshift documentation:
> 'Amazon Redshift locks tables to prevent two users from updating the same table at the same time'. [1](https://docs.aws.amazon.com/redshift/latest/dg/r_STV_LOCKS.html)
> 'Concurrent operations can originate from different sessions that are controlled either by the same user or by different users'. [2](https://docs.aws.amazon.com/redshift/latest/dg/c_serial_isolation.html)

In other words, when the `postgresql-user` module runs the additional statements for several users, there will be problems because the underlying processes try to update the same table (application or system) in a concurrency way.


_Solution_:
Using a **lock** in the command section of the local-exec provider in the terraform_data that manages the additional stataments.
This avoids several processes from accessing a shared resource in a concurrent way.
In our case, we ensure that only one process at time execute the additional statements on the Redshift cluster, avoiding errors due to concurrent transactions.