### PR TITLE
fix(terraform): relax aws provider pin in ses-identity and ses-iam-policy

### DIFF
--- a/terraform/modules/ses-iam-policy/00-main.tf
+++ b/terraform/modules/ses-iam-policy/00-main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.100.0"
+      version = ">= 5.100.0"
     }
   }
 }

--- a/terraform/modules/ses-iam-policy/README.md
+++ b/terraform/modules/ses-iam-policy/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.0, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.100.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.100.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.100.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.100.0 |
 
 ## Modules
 

--- a/terraform/modules/ses-identity/00-main.tf
+++ b/terraform/modules/ses-identity/00-main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.100.0"
+      version = ">= 5.100.0"
     }
   }
 }

--- a/terraform/modules/ses-identity/README.md
+++ b/terraform/modules/ses-identity/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.0, < 2.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.100.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.100.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.100.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.100.0 |
 
 ## Modules
 


### PR DESCRIPTION
Relaxes the AWS provider pin on the `ses-identity` and `ses-iam-policy` modules from `~> 5.100.0` (any 5.100.x only) to `>= 5.100.0` (5.100 or later), matching the constraint used by the rest of the modules in this repo and allowing consumers on AWS provider 6.x to use them.

**Context**

The current pin blocks any consumer on `hashicorp/aws >= 6.0.0` from using these two modules — `terraform init` fails with a `no available releases match the given constraints` error when both modules and the consumer are in the same Terraform root.

The APIGW modules received the same treatment in [`5afcec75`](https://github.com/pagopa/interop-infra-commons/commit/5afcec75) ("feat: bump APIGW modules provider", Mar 2026); this PR does the same for the SES modules.

**Safety assessment**

Cross-referenced the resources managed by both modules against AWS provider 6.x release notes:

- [v6 upgrade guide](https://github.com/hashicorp/terraform-provider-aws/blob/main/website/docs/guides/version-6-upgrade.html.markdown) contains **no mentions** of `aws_sesv2_email_identity`, `aws_sesv2_configuration_set`, `aws_sesv2_configuration_set_event_destination`, `aws_sesv2_email_identity_mail_from_attributes`, `aws_route53_record`, `aws_cloudwatch_metric_alarm`, or `aws_iam_policy`.
- The [v6.0.0 CHANGELOG](https://github.com/hashicorp/terraform-provider-aws/blob/v6.0.0/CHANGELOG.md) has no entries touching these resources.
- Across all 6.x releases: no BREAKING CHANGES for any of them. Only backward-compatible additions/fixes (e.g. `aws_route53_record` bug fix in 6.53.0, `aws_cloudwatch_metric_alarm` new optional args in 6.42.0).

**Validation performed**

- `terraform fmt -check -recursive -diff`
- `terraform-docs markdown table --output-mode inject` on both modules.